### PR TITLE
fix/use_api_for_Android_SDK_dependency_and_bump_version_11.4.3

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Versions
 
+## x.x.x
+    * Use `api` for Android AppLovin MAX SDK dependency.
+    * Depends on Android SDK v11.4.3. 
 ## 1.0.2
     * Fix `RewardededAdListener` typo to be `RewardedAdListener`.
 ## 1.0.1

--- a/applovin_max/android/build.gradle
+++ b/applovin_max/android/build.gradle
@@ -34,6 +34,6 @@ android {
     }
 
     dependencies {
-        implementation 'com.applovin:applovin-sdk:11.4.2'
+        api 'com.applovin:applovin-sdk:11.4.3'
     }
 }

--- a/applovin_max/example/android/app/build.gradle
+++ b/applovin_max/example/android/app/build.gradle
@@ -51,7 +51,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.applovin:applovin-sdk:11.4.2'
+
     }
 }
 


### PR DESCRIPTION
https://github.com/AppLovin/AppLovin-MAX-Flutter/issues/7#issuecomment-1163601282