### PR TITLE
ref/fix_static_analyze

### DIFF
--- a/applovin_max/example/lib/main.dart
+++ b/applovin_max/example/lib/main.dart
@@ -19,12 +19,12 @@ class MyApp extends StatefulWidget {
 }
 
 // Create constants
-final String _sdk_key = "YOUR_SDK_KEY";
+const String _sdkKey = "YOUR_SDK_KEY";
 
-final String _interstitial_ad_unit_id = Platform.isAndroid ? "ANDROID_INTER_AD_UNIT_ID" : "IOS_INTER_AD_UNIT_ID";
-final String _rewarded_ad_unit_id = Platform.isAndroid ? "ANDROID_REWARDED_AD_UNIT_ID" : "IOS_REWARDED_AD_UNIT_ID";
-final String _banner_ad_unit_id = Platform.isAndroid ? "ANDROID_BANNER_AD_UNIT_ID" : "IOS_BANNER_AD_UNIT_ID";
-final String _mrec_ad_unit_id = Platform.isAndroid ? "ANDROID_MREC_AD_UNIT_ID" : "IOS_MREC_AD_UNIT_ID";
+final String _interstitialAdUnitId = Platform.isAndroid ? "ANDROID_INTER_AD_UNIT_ID" : "IOS_INTER_AD_UNIT_ID";
+final String _rewardedAdUnitId = Platform.isAndroid ? "ANDROID_REWARDED_AD_UNIT_ID" : "IOS_REWARDED_AD_UNIT_ID";
+final String _bannerAdUnitId = Platform.isAndroid ? "ANDROID_BANNER_AD_UNIT_ID" : "IOS_BANNER_AD_UNIT_ID";
+final String _mrecAdUnitId = Platform.isAndroid ? "ANDROID_MREC_AD_UNIT_ID" : "IOS_MREC_AD_UNIT_ID";
 
 // Create states
 var _isInitialized = false;
@@ -52,7 +52,7 @@ class _MyAppState extends State<MyApp> {
   Future<void> initializePlugin() async {
     logStatus("Initializing SDK...");
 
-    Map? configuration = await AppLovinMAX.initialize(_sdk_key);
+    Map? configuration = await AppLovinMAX.initialize(_sdkKey);
     if (configuration != null) {
       _isInitialized = true;
 
@@ -69,7 +69,7 @@ class _MyAppState extends State<MyApp> {
         _interstitialLoadState = AdLoadState.loaded;
 
         // Interstitial ad is ready to be shown. AppLovinMAX.isInterstitialAdReady(_interstitial_ad_unit_id) will now return 'true'
-        logStatus('Interstitial ad loaded from ' + ad.networkName);
+        logStatus('Interstitial ad loaded from ${ad.networkName}');
 
         // Reset retry attempt
         _interstitialRetryAttempt = 0;
@@ -82,10 +82,10 @@ class _MyAppState extends State<MyApp> {
         _interstitialRetryAttempt = _interstitialRetryAttempt + 1;
 
         int retryDelay = pow(2, min(6, _interstitialRetryAttempt)).toInt();
-        logStatus('Interstitial ad failed to load with code ' + error.code.toString() + ' - retrying in ' + retryDelay.toString() + 's');
+        logStatus('Interstitial ad failed to load with code ${error.code} - retrying in ${retryDelay}s');
 
         Future.delayed(Duration(milliseconds: retryDelay * 1000), () {
-          AppLovinMAX.loadInterstitial(_interstitial_ad_unit_id);
+          AppLovinMAX.loadInterstitial(_interstitialAdUnitId);
         });
       },
       onAdDisplayedCallback: (ad) {
@@ -93,7 +93,7 @@ class _MyAppState extends State<MyApp> {
       },
       onAdDisplayFailedCallback: (ad, error) {
         _interstitialLoadState = AdLoadState.notLoaded;
-        logStatus('Interstitial ad failed to display with code ' + error.code.toString() + ' and message ' + error.message);
+        logStatus('Interstitial ad failed to display with code ${error.code} and message ${error.message}');
       },
       onAdClickedCallback: (ad) {
         logStatus('Interstitial ad clicked');
@@ -109,7 +109,7 @@ class _MyAppState extends State<MyApp> {
       _rewardedAdLoadState = AdLoadState.loaded;
 
       // Rewarded ad is ready to be shown. AppLovinMAX.isRewardedAdReady(_rewarded_ad_unit_id) will now return 'true'
-      logStatus('Rewarded ad loaded from ' + ad.networkName);
+      logStatus('Rewarded ad loaded from ${ad.networkName}');
 
       // Reset retry attempt
       _rewardedAdRetryAttempt = 0;
@@ -121,16 +121,16 @@ class _MyAppState extends State<MyApp> {
       _rewardedAdRetryAttempt = _rewardedAdRetryAttempt + 1;
 
       int retryDelay = pow(2, min(6, _rewardedAdRetryAttempt)).toInt();
-      logStatus('Rewarded ad failed to load with code ' + error.code.toString() + ' - retrying in ' + retryDelay.toString() + 's');
+      logStatus('Rewarded ad failed to load with code ${error.code} - retrying in ${retryDelay}s');
 
       Future.delayed(Duration(milliseconds: retryDelay * 1000), () {
-        AppLovinMAX.loadRewardedAd(_rewarded_ad_unit_id);
+        AppLovinMAX.loadRewardedAd(_rewardedAdUnitId);
       });
     }, onAdDisplayedCallback: (ad) {
       logStatus('Rewarded ad displayed');
     }, onAdDisplayFailedCallback: (ad, error) {
       _rewardedAdLoadState = AdLoadState.notLoaded;
-      logStatus('Rewarded ad failed to display with code ' + error.code.toString() + ' and message ' + error.message);
+      logStatus('Rewarded ad failed to display with code ${error.code} and message ${error.message}');
     }, onAdClickedCallback: (ad) {
       logStatus('Rewarded ad clicked');
     }, onAdHiddenCallback: (ad) {
@@ -142,9 +142,9 @@ class _MyAppState extends State<MyApp> {
 
     /// Banner Ad Listeners
     AppLovinMAX.setBannerListener(AdViewAdListener(onAdLoadedCallback: (ad) {
-      logStatus('Banner ad loaded from ' + ad.networkName);
+      logStatus('Banner ad loaded from ${ad.networkName}');
     }, onAdLoadFailedCallback: (adUnitId, error) {
-      logStatus('Banner ad failed to load with error code ' + error.code.toString() + ' and message: ' + error.message);
+      logStatus('Banner ad failed to load with error code ${error.code} and message: ${error.message}');
     }, onAdClickedCallback: (ad) {
       logStatus('Banner ad clicked');
     }, onAdExpandedCallback: (ad) {
@@ -155,9 +155,9 @@ class _MyAppState extends State<MyApp> {
 
     /// MREC Ad Listeners
     AppLovinMAX.setMRecListener(AdViewAdListener(onAdLoadedCallback: (ad) {
-      logStatus('MREC ad loaded from ' + ad.networkName);
+      logStatus('MREC ad loaded from ${ad.networkName}');
     }, onAdLoadFailedCallback: (adUnitId, error) {
-      logStatus('MREC ad failed to load with error code ' + error.code.toString() + ' and message: ' + error.message);
+      logStatus('MREC ad failed to load with error code ${error.code} and message: ${error.message}');
     }, onAdClickedCallback: (ad) {
       logStatus('MREC ad clicked');
     }, onAdExpandedCallback: (ad) {
@@ -204,6 +204,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   void logStatus(String status) {
+    /// ignore: avoid_print
     print(status);
 
     setState(() {
@@ -216,15 +217,15 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       home: Scaffold(
           appBar: AppBar(
-            title: Text("AppLovin MAX Demo"),
+            title: const Text("AppLovin MAX Demo"),
           ),
           body: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              SizedBox(height: 20),
+              const SizedBox(height: 20),
               Text(
                 '$_statusText\n',
-                style: TextStyle(fontSize: 20),
+                style: const TextStyle(fontSize: 20),
                 textAlign: TextAlign.center,
               ),
               ElevatedButton(
@@ -233,18 +234,18 @@ class _MyAppState extends State<MyApp> {
                         AppLovinMAX.showMediationDebugger();
                       }
                     : null,
-                child: Text("Mediation Debugger"),
+                child: const Text("Mediation Debugger"),
               ),
               ElevatedButton(
                 onPressed: (_isInitialized && _interstitialLoadState != AdLoadState.loading)
                     ? () async {
-                        bool isReady = (await AppLovinMAX.isInterstitialReady(_interstitial_ad_unit_id))!;
+                        bool isReady = (await AppLovinMAX.isInterstitialReady(_interstitialAdUnitId))!;
                         if (isReady) {
-                          AppLovinMAX.showInterstitial(_interstitial_ad_unit_id);
+                          AppLovinMAX.showInterstitial(_interstitialAdUnitId);
                         } else {
                           logStatus('Loading interstitial ad...');
                           _interstitialLoadState = AdLoadState.loading;
-                          AppLovinMAX.loadInterstitial(_interstitial_ad_unit_id);
+                          AppLovinMAX.loadInterstitial(_interstitialAdUnitId);
                         }
                       }
                     : null,
@@ -253,13 +254,13 @@ class _MyAppState extends State<MyApp> {
               ElevatedButton(
                 onPressed: (_isInitialized && _rewardedAdLoadState != AdLoadState.loading)
                     ? () async {
-                        bool isReady = (await AppLovinMAX.isRewardedAdReady(_rewarded_ad_unit_id))!;
+                        bool isReady = (await AppLovinMAX.isRewardedAdReady(_rewardedAdUnitId))!;
                         if (isReady) {
-                          AppLovinMAX.showRewardedAd(_rewarded_ad_unit_id);
+                          AppLovinMAX.showRewardedAd(_rewardedAdUnitId);
                         } else {
                           logStatus('Loading rewarded ad...');
                           _rewardedAdLoadState = AdLoadState.loading;
-                          AppLovinMAX.loadRewardedAd(_rewarded_ad_unit_id);
+                          AppLovinMAX.loadRewardedAd(_rewardedAdUnitId);
                         }
                       }
                     : null,
@@ -272,21 +273,21 @@ class _MyAppState extends State<MyApp> {
                     onPressed: (_isInitialized && !_isWidgetBannerShowing)
                         ? () async {
                             if (_isProgrammaticBannerShowing) {
-                              AppLovinMAX.hideBanner(_banner_ad_unit_id);
+                              AppLovinMAX.hideBanner(_bannerAdUnitId);
                             } else {
                               if (!_isProgrammaticBannerCreated) {
                                 //
                                 // Programmatic banner creation - banners are automatically sized to 320x50 on phones and 728x90 on tablets
                                 //
-                                AppLovinMAX.createBanner(_banner_ad_unit_id, AdViewPosition.bottomCenter);
+                                AppLovinMAX.createBanner(_bannerAdUnitId, AdViewPosition.bottomCenter);
 
                                 // Set banner background color to black - PLEASE USE HEX STRINGS ONLY
-                                AppLovinMAX.setBannerBackgroundColor(_banner_ad_unit_id, '#000000');
+                                AppLovinMAX.setBannerBackgroundColor(_bannerAdUnitId, '#000000');
 
                                 _isProgrammaticBannerCreated = true;
                               }
 
-                              AppLovinMAX.showBanner(_banner_ad_unit_id);
+                              AppLovinMAX.showBanner(_bannerAdUnitId);
                             }
 
                             setState(() {
@@ -315,15 +316,15 @@ class _MyAppState extends State<MyApp> {
                     onPressed: (_isInitialized && !_isWidgetMRecShowing)
                         ? () async {
                             if (_isProgrammaticMRecShowing) {
-                              AppLovinMAX.hideMRec(_mrec_ad_unit_id);
+                              AppLovinMAX.hideMRec(_mrecAdUnitId);
                             } else {
                               if (!_isProgrammaticMRecCreated) {
-                                AppLovinMAX.createMRec(_mrec_ad_unit_id, AdViewPosition.bottomCenter);
+                                AppLovinMAX.createMRec(_mrecAdUnitId, AdViewPosition.bottomCenter);
 
                                 _isProgrammaticMRecCreated = true;
                               }
 
-                              AppLovinMAX.showMRec(_mrec_ad_unit_id);
+                              AppLovinMAX.showMRec(_mrecAdUnitId);
                             }
 
                             setState(() {
@@ -347,12 +348,12 @@ class _MyAppState extends State<MyApp> {
               ),
               if (_isWidgetBannerShowing)
                 MaxAdView(
-                    adUnitId: _banner_ad_unit_id,
+                    adUnitId: _bannerAdUnitId,
                     adFormat: AdFormat.banner,
                     listener: AdViewAdListener(onAdLoadedCallback: (ad) {
-                      logStatus('Banner widget ad loaded from ' + ad.networkName);
+                      logStatus('Banner widget ad loaded from ${ad.networkName}');
                     }, onAdLoadFailedCallback: (adUnitId, error) {
-                      logStatus('Banner widget ad failed to load with error code ' + error.code.toString() + ' and message: ' + error.message);
+                      logStatus('Banner widget ad failed to load with error code ${error.code} and message: ${error.message}');
                     }, onAdClickedCallback: (ad) {
                       logStatus('Banner widget ad clicked');
                     }, onAdExpandedCallback: (ad) {
@@ -362,12 +363,12 @@ class _MyAppState extends State<MyApp> {
                     })),
               if (_isWidgetMRecShowing)
                 MaxAdView(
-                    adUnitId: _mrec_ad_unit_id,
+                    adUnitId: _mrecAdUnitId,
                     adFormat: AdFormat.mrec,
                     listener: AdViewAdListener(onAdLoadedCallback: (ad) {
-                      logStatus('MREC widget ad loaded from ' + ad.networkName);
+                      logStatus('MREC widget ad loaded from ${ad.networkName}');
                     }, onAdLoadFailedCallback: (adUnitId, error) {
-                      logStatus('MREC widget ad failed to load with error code ' + error.code.toString() + ' and message: ' + error.message);
+                      logStatus('MREC widget ad failed to load with error code ${error.code} and message: ${error.message}');
                     }, onAdClickedCallback: (ad) {
                       logStatus('MREC widget ad clicked');
                     }, onAdExpandedCallback: (ad) {

--- a/applovin_max/example/pubspec.yaml
+++ b/applovin_max/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: AppLovin_MAX_Example
+name: applovin_max_example
 description: Demonstrates how to use the AppLovin MAX plugin.
 
 # The following line prevents the package from being accidentally published to

--- a/applovin_max/lib/src/ad_classes.dart
+++ b/applovin_max/lib/src/ad_classes.dart
@@ -11,19 +11,7 @@ class MaxAd {
 
   @override
   String toString() {
-    return "[MaxAd adUnitId: " +
-        adUnitId +
-        ", networkName: " +
-        networkName +
-        ", revenue: " +
-        revenue +
-        ", dspName: " +
-        dspName +
-        ", creativeId: " +
-        creativeId +
-        ", placement: " +
-        placement! +
-        "]";
+    return '[MaxAd adUnitId: $adUnitId, networkName: $networkName, revenue: $revenue, dspName: $dspName, creativeId: $creativeId, placement: $placement!]';
   }
 }
 
@@ -35,7 +23,7 @@ class MaxReward {
 
   @override
   String toString() {
-    return "[MaxReward amount: " + amount.toString() + ", label: " + label + "]";
+    return '[MaxReward amount: $amount, label: $label]';
   }
 }
 
@@ -47,6 +35,6 @@ class MaxError {
 
   @override
   String toString() {
-    return "[MaxError code: " + code.toString() + ", message: " + message + "]";
+    return '[MaxError code: $code, message: $message]';
   }
 }

--- a/applovin_max/lib/src/max_ad_view.dart
+++ b/applovin_max/lib/src/max_ad_view.dart
@@ -16,12 +16,12 @@ enum AdFormat {
   const AdFormat(this.value);
 }
 
-final double _banner_width = 320;
-final double _banner_height = 50;
-final double _leader_width = 728;
-final double _leader_height = 90;
-final double _mrec_width = 300;
-final double _mrec_height = 250;
+const double _bannerWidth = 320;
+const double _bannerHeight = 50;
+const double _leaderWidth = 728;
+const double _leaderHeight = 90;
+const double _mrecWidth = 300;
+const double _mrecHeight = 250;
 
 class MaxAdView extends StatefulWidget {
   /// A string value representing the ad unit id to load ads for.
@@ -49,7 +49,7 @@ class MaxAdView extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _MaxAdViewState createState() => _MaxAdViewState();
+  State<MaxAdView> createState() => _MaxAdViewState();
 }
 
 class _MaxAdViewState extends State<MaxAdView> {
@@ -120,9 +120,9 @@ class _MaxAdViewState extends State<MaxAdView> {
 
   double _getWidth() {
     if (widget.adFormat == AdFormat.mrec) {
-      return _mrec_width;
+      return _mrecWidth;
     } else if (widget.adFormat == AdFormat.banner) {
-      return _isTablet() ? _leader_width : _banner_width;
+      return _isTablet() ? _leaderWidth : _bannerWidth;
     }
 
     return -1;
@@ -130,9 +130,9 @@ class _MaxAdViewState extends State<MaxAdView> {
 
   double _getHeight() {
     if (widget.adFormat == AdFormat.mrec) {
-      return _mrec_height;
+      return _mrecHeight;
     } else if (widget.adFormat == AdFormat.banner) {
-      return _isTablet() ? _leader_height : _banner_height;
+      return _isTablet() ? _leaderHeight : _bannerHeight;
     }
 
     return -1;


### PR DESCRIPTION
Fixed to pass 'flutter analyze':

- Lower camel case:  _xxx_yyy => _xxxYYY
- Prefer const:   final => const
- Interpolation strings:  "This is " + $value => 'This is $value'
- Public APIs:  _MaxAdViewState => State<MaxAdView>
- Lower package name: AppLovin_MAX_Example => applovin_max_example

The original output from 'flutter analyze':

```
Analyzing applovin_max...                                       

  info • Prefer const over final for declarations • example/lib/main.dart:22:1 • prefer_const_declarations
   info • Name non-constant identifiers using lowerCamelCase • example/lib/main.dart:22:14 • non_constant_identifier_names
   info • Name non-constant identifiers using lowerCamelCase • example/lib/main.dart:24:14 • non_constant_identifier_names
   info • Name non-constant identifiers using lowerCamelCase • example/lib/main.dart:25:14 • non_constant_identifier_names
   info • Name non-constant identifiers using lowerCamelCase • example/lib/main.dart:26:14 • non_constant_identifier_names
   info • Name non-constant identifiers using lowerCamelCase • example/lib/main.dart:27:14 • non_constant_identifier_names
   info • Use interpolation to compose strings and values • example/lib/main.dart:72:19 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • example/lib/main.dart:85:19 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • example/lib/main.dart:96:19 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • example/lib/main.dart:112:17 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • example/lib/main.dart:124:17 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • example/lib/main.dart:133:17 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • example/lib/main.dart:145:17 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • example/lib/main.dart:147:17 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • example/lib/main.dart:158:17 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • example/lib/main.dart:160:17 • prefer_interpolation_to_compose_strings
   info • Avoid `print` calls in production code • example/lib/main.dart:207:5 • avoid_print
   info • Prefer const with constant constructors • example/lib/main.dart:219:20 • prefer_const_constructors
   info • Prefer const with constant constructors • example/lib/main.dart:224:15 • prefer_const_constructors
   info • Prefer const with constant constructors • example/lib/main.dart:227:24 • prefer_const_constructors
   info • Prefer const with constant constructors • example/lib/main.dart:236:24 • prefer_const_constructors
   info • Use interpolation to compose strings and values • example/lib/main.dart:353:33 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • example/lib/main.dart:355:33 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • example/lib/main.dart:368:33 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • example/lib/main.dart:370:33 • prefer_interpolation_to_compose_strings
   info • Use `lowercase_with_underscores` for package names • example/pubspec.yaml:1:7 • package_names
   info • Use interpolation to compose strings and values • lib/src/ad_classes.dart:14:12 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • lib/src/ad_classes.dart:38:12 • prefer_interpolation_to_compose_strings
   info • Use interpolation to compose strings and values • lib/src/ad_classes.dart:50:12 • prefer_interpolation_to_compose_strings
   info • Prefer const over final for declarations • lib/src/max_ad_view.dart:19:1 • prefer_const_declarations
   info • Name non-constant identifiers using lowerCamelCase • lib/src/max_ad_view.dart:19:14 • non_constant_identifier_names
   info • Prefer const over final for declarations • lib/src/max_ad_view.dart:20:1 • prefer_const_declarations
   info • Name non-constant identifiers using lowerCamelCase • lib/src/max_ad_view.dart:20:14 • non_constant_identifier_names
   info • Prefer const over final for declarations • lib/src/max_ad_view.dart:21:1 • prefer_const_declarations
   info • Name non-constant identifiers using lowerCamelCase • lib/src/max_ad_view.dart:21:14 • non_constant_identifier_names
   info • Prefer const over final for declarations • lib/src/max_ad_view.dart:22:1 • prefer_const_declarations
   info • Name non-constant identifiers using lowerCamelCase • lib/src/max_ad_view.dart:22:14 • non_constant_identifier_names
   info • Prefer const over final for declarations • lib/src/max_ad_view.dart:23:1 • prefer_const_declarations
   info • Name non-constant identifiers using lowerCamelCase • lib/src/max_ad_view.dart:23:14 • non_constant_identifier_names
   info • Prefer const over final for declarations • lib/src/max_ad_view.dart:24:1 • prefer_const_declarations
   info • Name non-constant identifiers using lowerCamelCase • lib/src/max_ad_view.dart:24:14 • non_constant_identifier_names
   info • Avoid using private types in public APIs • lib/src/max_ad_view.dart:52:3 • library_private_types_in_public_api
```


