### PR TITLE
feat/support_waterfall

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Versions
 
 ## x.x.x
-    * Add support for ad waterfall.
-    * Add support for `AppLovinMAX.setLocationCollectionEnabled(bool enabled)` API
+    * Add support for waterfall info API.
+    * Add support for `AppLovinMAX.setLocationCollectionEnabled(bool enabled)` API.
 ## 2.3.1
     * Fix banner/MREC widget ad issue on Android. (https://github.com/AppLovin/AppLovin-MAX-Flutter/issues/32)
 ## 2.3.0

--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+    * Add support for ad waterfall.
     * Add support for `AppLovinMAX.setLocationCollectionEnabled(bool enabled)` API
 ## 2.3.1
     * Fix banner/MREC widget ad issue on Android. (https://github.com/AppLovin/AppLovin-MAX-Flutter/issues/32)

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
@@ -1406,9 +1406,8 @@ public class AppLovinMAX
         MaxError error = response.getError();
         if ( error != null )
         {
-            Map<String, Object> errorObject = new HashMap<>( 3 );
+            Map<String, Object> errorObject = new HashMap<>( 2 );
             errorObject.put( "message", error.getMessage() );
-            errorObject.put( "adLoadFailureInfo", error.getAdLoadFailureInfo() );
             errorObject.put( "code", error.getCode() );
 
             networkResponseObject.put( "error", errorObject );

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdView.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdView.java
@@ -77,11 +77,7 @@ public class AppLovinMAXAdView
     @Override
     public void onAdLoadFailed(final String adUnitId, final MaxError error)
     {
-        Map<String, String> params = new HashMap<String, String>( 2 );
-        params.put( "adUnitId", adUnitId );
-        params.put( "errorCode", String.valueOf( error.getCode() ) );
-
-        AppLovinMAX.getInstance().fireCallback( "OnAdViewAdLoadFailedEvent", params, channel );
+        AppLovinMAX.getInstance().fireErrorCallback( "OnAdViewAdLoadFailedEvent", adUnitId, error );
     }
 
     @Override

--- a/applovin_max/example/lib/main.dart
+++ b/applovin_max/example/lib/main.dart
@@ -103,7 +103,7 @@ class _MyAppState extends State<MyApp> {
         logStatus('Interstitial ad hidden');
       },
       onAdRevenuePaidCallback: (ad) {
-        logStatus('Interstitial ad revenue paid: $ad.revenue');
+        logStatus('Interstitial ad revenue paid: ${ad.revenue}');
       },
     ));
 
@@ -142,7 +142,7 @@ class _MyAppState extends State<MyApp> {
     }, onAdReceivedRewardCallback: (ad, reward) {
       logStatus('Rewarded ad granted reward');
     }, onAdRevenuePaidCallback: (ad) {
-      logStatus('Rewarded ad revenue paid: $ad.revenue');
+      logStatus('Rewarded ad revenue paid: ${ad.revenue}');
     }));
 
     /// Banner Ad Listeners
@@ -157,7 +157,7 @@ class _MyAppState extends State<MyApp> {
     }, onAdCollapsedCallback: (ad) {
       logStatus('Banner ad collapsed');
     }, onAdRevenuePaidCallback: (ad) {
-      logStatus('Banner ad revenue paid: $ad.revenue');
+      logStatus('Banner ad revenue paid: ${ad.revenue}');
     }));
 
     /// MREC Ad Listeners
@@ -172,7 +172,7 @@ class _MyAppState extends State<MyApp> {
     }, onAdCollapsedCallback: (ad) {
       logStatus('MREC ad collapsed');
     }, onAdRevenuePaidCallback: (ad) {
-      logStatus('MREC ad revenue paid: $ad.revenue');
+      logStatus('MREC ad revenue paid: ${ad.revenue}');
     }));
   }
 
@@ -370,7 +370,7 @@ class _MyAppState extends State<MyApp> {
                     }, onAdCollapsedCallback: (ad) {
                       logStatus('Banner widget ad collapsed');
                     }, onAdRevenuePaidCallback: (ad) {
-                      logStatus('Banner widget ad revenue paid: $ad.revenue');
+                      logStatus('Banner widget ad revenue paid: ${ad.revenue}');
                     })),
               if (_isWidgetMRecShowing)
                 MaxAdView(
@@ -387,7 +387,7 @@ class _MyAppState extends State<MyApp> {
                     }, onAdCollapsedCallback: (ad) {
                       logStatus('MREC widget ad collapsed');
                     }, onAdRevenuePaidCallback: (ad) {
-                      logStatus('MREC widget ad revenue paid: $ad.revenue');
+                      logStatus('MREC widget ad revenue paid: ${ad.revenue}');
                     })),
             ],
           )),

--- a/applovin_max/ios/Classes/AppLovinMAX.h
+++ b/applovin_max/ios/Classes/AppLovinMAX.h
@@ -25,6 +25,11 @@
  */
 - (void)sendEventWithName:(NSString *)name body:(NSDictionary<NSString *, NSString *> *)body channel:(FlutterMethodChannel *)channel;
 
+/**
+ * Utility method for sending error events through the Flutter channel into Dart.
+ */
+- (void)sendErrorEventWithName:(NSString *)name forAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(MAError *)error;
+
 + (void)log:(NSString *)format, ...;
 
 @end

--- a/applovin_max/ios/Classes/AppLovinMAX.m
+++ b/applovin_max/ios/Classes/AppLovinMAX.m
@@ -1365,7 +1365,6 @@ static FlutterMethodChannel *ALSharedChannel;
     {
         NSMutableDictionary<NSString *, NSObject *> *errorObject = [NSMutableDictionary dictionary];
         errorObject[@"message"] = error.message;
-        errorObject[@"adLoadFailure"] = error.adLoadFailureInfo;
         errorObject[@"code"] = @(error.code);
         
         networkResponseDict[@"error"] = errorObject;

--- a/applovin_max/ios/Classes/AppLovinMAXAdView.m
+++ b/applovin_max/ios/Classes/AppLovinMAXAdView.m
@@ -57,10 +57,9 @@
 
 - (void)didFailToLoadAdForAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(MAError *)error
 {
-    [[AppLovinMAX shared] sendEventWithName: @"OnAdViewAdLoadFailedEvent"
-                                       body: @{@"adUnitId" : adUnitIdentifier,
-                                               @"errorCode" : [@(error.code) stringValue]}
-                                    channel: self.channel];
+    [[AppLovinMAX shared] sendErrorEventWithName: @"OnAdViewAdLoadFailedEvent"
+                             forAdUnitIdentifier: adUnitIdentifier
+                                       withError: error];
 }
 
 - (void)didClickAd:(MAAd *)ad

--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -46,8 +46,7 @@ class AppLovinMAX {
       if ("OnBannerAdLoadedEvent" == method) {
         _bannerAdListener?.onAdLoadedCallback(createAd(adUnitId, arguments));
       } else if ("OnBannerAdLoadFailedEvent" == method) {
-        var error = MaxError(arguments["errorCode"], arguments["errorMessage"]);
-        _bannerAdListener?.onAdLoadFailedCallback(adUnitId, error);
+        _bannerAdListener?.onAdLoadFailedCallback(adUnitId, createError(arguments));
       } else if ("OnBannerAdClickedEvent" == method) {
         _bannerAdListener?.onAdClickedCallback(createAd(adUnitId, arguments));
       } else if ("OnBannerAdExpandedEvent" == method) {
@@ -62,8 +61,7 @@ class AppLovinMAX {
       else if ("OnMRecAdLoadedEvent" == method) {
         _mrecAdListener?.onAdLoadedCallback(createAd(adUnitId, arguments));
       } else if ("OnMRecAdLoadFailedEvent" == method) {
-        var error = MaxError(arguments["errorCode"], arguments["errorMessage"]);
-        _mrecAdListener?.onAdLoadFailedCallback(adUnitId, error);
+        _mrecAdListener?.onAdLoadFailedCallback(adUnitId, createError(arguments));
       } else if ("OnMRecAdClickedEvent" == method) {
         _mrecAdListener?.onAdClickedCallback(createAd(adUnitId, arguments));
       } else if ("OnMRecAdExpandedEvent" == method) {
@@ -78,15 +76,13 @@ class AppLovinMAX {
       else if ("OnInterstitialLoadedEvent" == method) {
         _interstitialListener?.onAdLoadedCallback.call(createAd(adUnitId, arguments));
       } else if ("OnInterstitialLoadFailedEvent" == method) {
-        var error = MaxError(arguments["errorCode"], arguments["errorMessage"]);
-        _interstitialListener?.onAdLoadFailedCallback(adUnitId, error);
+        _interstitialListener?.onAdLoadFailedCallback(adUnitId, createError(arguments));
       } else if ("OnInterstitialClickedEvent" == method) {
         _interstitialListener?.onAdClickedCallback.call(createAd(adUnitId, arguments));
       } else if ("OnInterstitialDisplayedEvent" == method) {
         _interstitialListener?.onAdDisplayedCallback.call(createAd(adUnitId, arguments));
       } else if ("OnInterstitialAdFailedToDisplayEvent" == method) {
-        var error = MaxError(arguments["errorCode"], arguments["errorMessage"]);
-        _interstitialListener?.onAdDisplayFailedCallback(createAd(adUnitId, arguments), error);
+        _interstitialListener?.onAdDisplayFailedCallback(createAd(adUnitId, arguments), createError(arguments));
       } else if ("OnInterstitialHiddenEvent" == method) {
         _interstitialListener?.onAdHiddenCallback.call(createAd(adUnitId, arguments));
       } else if ("OnInterstitialAdRevenuePaid" == method) {
@@ -97,19 +93,17 @@ class AppLovinMAX {
       else if ("OnRewardedAdLoadedEvent" == method) {
         _rewardedAdListener?.onAdLoadedCallback.call(createAd(adUnitId, arguments));
       } else if ("OnRewardedAdLoadFailedEvent" == method) {
-        var error = MaxError(arguments["errorCode"], arguments["errorMessage"]);
-        _rewardedAdListener?.onAdLoadFailedCallback(adUnitId, error);
+        _rewardedAdListener?.onAdLoadFailedCallback(adUnitId, createError(arguments));
       } else if ("OnRewardedAdClickedEvent" == method) {
         _rewardedAdListener?.onAdClickedCallback.call(createAd(adUnitId, arguments));
       } else if ("OnRewardedAdDisplayedEvent" == method) {
         _rewardedAdListener?.onAdDisplayedCallback.call(createAd(adUnitId, arguments));
       } else if ("OnRewardedAdFailedToDisplayEvent" == method) {
-        var error = MaxError(arguments["errorCode"], arguments["errorMessage"]);
-        _rewardedAdListener?.onAdDisplayFailedCallback(createAd(adUnitId, arguments), error);
+        _rewardedAdListener?.onAdDisplayFailedCallback(createAd(adUnitId, arguments), createError(arguments));
       } else if ("OnRewardedAdHiddenEvent" == method) {
         _rewardedAdListener?.onAdHiddenCallback.call(createAd(adUnitId, arguments));
       } else if ("OnRewardedAdReceivedRewardEvent" == method) {
-        var reward = MaxReward(int.parse(arguments["rewardAmount"]), arguments["rewardLabel"]);
+        var reward = MaxReward(arguments["rewardAmount"], arguments["rewardLabel"]);
         _rewardedAdListener?.onAdReceivedRewardCallback(createAd(adUnitId, arguments), reward);
       } else if ("OnRewardedAdRevenuePaid" == method) {
         _rewardedAdListener?.onAdRevenuePaidCallback?.call(createAd(adUnitId, arguments));
@@ -119,15 +113,13 @@ class AppLovinMAX {
       else if ("OnAppOpenAdLoadedEvent" == method) {
         _appOpenAdListener?.onAdLoadedCallback.call(createAd(adUnitId, arguments));
       } else if ("OnAppOpenAdLoadFailedEvent" == method) {
-        var error = MaxError(arguments["errorCode"], arguments["errorMessage"]);
-        _appOpenAdListener?.onAdLoadFailedCallback(adUnitId, error);
+        _appOpenAdListener?.onAdLoadFailedCallback(adUnitId, createError(arguments));
       } else if ("OnAppOpenAdClickedEvent" == method) {
         _appOpenAdListener?.onAdClickedCallback.call(createAd(adUnitId, arguments));
       } else if ("OnAppOpenAdDisplayedEvent" == method) {
         _appOpenAdListener?.onAdDisplayedCallback.call(createAd(adUnitId, arguments));
       } else if ("OnAppOpenAdFailedToDisplayEvent" == method) {
-        var error = MaxError(arguments["errorCode"], arguments["errorMessage"]);
-        _appOpenAdListener?.onAdDisplayFailedCallback(createAd(adUnitId, arguments), error);
+        _appOpenAdListener?.onAdDisplayFailedCallback(createAd(adUnitId, arguments), createError(arguments));
       } else if ("OnAppOpenAdHiddenEvent" == method) {
         _appOpenAdListener?.onAdHiddenCallback.call(createAd(adUnitId, arguments));
       } else if ("OnAppOpenAdRevenuePaid" == method) {
@@ -150,6 +142,17 @@ class AppLovinMAX {
       arguments["creativeId"],
       arguments["dspName"],
       arguments["placement"],
+      Map<String, dynamic>.from(arguments["waterfall"]),
+    );
+  }
+
+  /// @nodoc
+  static MaxError createError(dynamic arguments) {
+    return MaxError(
+      arguments["errorCode"],
+      arguments["errorMessage"],
+      arguments["adLoadFailureInfo"],
+      Map<String, dynamic>.from(arguments["waterfall"]),
     );
   }
 

--- a/applovin_max/lib/src/ad_classes.dart
+++ b/applovin_max/lib/src/ad_classes.dart
@@ -5,20 +5,22 @@ class MaxAd {
   /// The ad network from which this ad was loaded.
   final String networkName;
   /// The ad’s revenue amount, or 0 if no revenue amount exists.
-  final String revenue;
+  final double revenue;
   /// The creative ID tied to the ad, if any. You can report creative issues to the corresponding ad network using this ID.
   final String creativeId;
   /// The DSP network that provided the loaded ad when the ad is served through AppLovin Exchange.
   final String dspName;
   ///  The placement name that you assign when you integrate each ad format.
-  String? placement;
+  final String placement;
+  /// The underlying waterfall of ad responses.
+  final Map<String, dynamic> waterfall;
 
   /// @nodoc
-  MaxAd(this.adUnitId, this.networkName, this.revenue, this.creativeId, this.dspName, this.placement);
+  MaxAd(this.adUnitId, this.networkName, this.revenue, this.creativeId, this.dspName, this.placement, this.waterfall);
 
   @override
   String toString() {
-    return '[MaxAd adUnitId: $adUnitId, networkName: $networkName, revenue: $revenue, dspName: $dspName, creativeId: $creativeId, placement: $placement!]';
+    return '[MaxAd adUnitId: $adUnitId, networkName: $networkName, revenue: $revenue, dspName: $dspName, creativeId: $creativeId, placement: $placement, waterfall: $waterfall]';
   }
 }
 
@@ -44,12 +46,16 @@ class MaxError {
   final int code;
   /// The error message for the error.
   final String message;
+  /// The failure info for ad load
+  final String adLoadFailureInfo;
+  /// The underlying waterfall of ad responses.
+  final Map<String, dynamic> waterfall;
 
   /// @nodoc
-  MaxError(this.code, this.message);
+  MaxError(this.code, this.message, this.adLoadFailureInfo, this.waterfall);
 
   @override
   String toString() {
-    return '[MaxError code: $code, message: $message]';
+    return '[MaxError code: $code, message: $message, info: $adLoadFailureInfo, waterfall: $waterfall]';
   }
 }

--- a/applovin_max/lib/src/max_ad_view.dart
+++ b/applovin_max/lib/src/max_ad_view.dart
@@ -116,8 +116,7 @@ class _MaxAdViewState extends State<MaxAdView> {
       if ("OnAdViewAdLoadedEvent" == method) {
         widget.listener?.onAdLoadedCallback(AppLovinMAX.createAd(adUnitId, arguments));
       } else if ("OnAdViewAdLoadFailedEvent" == method) {
-        var error = MaxError(arguments["errorCode"], arguments["errorMessage"]);
-        widget.listener?.onAdLoadFailedCallback(adUnitId, error);
+        widget.listener?.onAdLoadFailedCallback(adUnitId, AppLovinMAX.createError(arguments));
       } else if ("OnAdViewAdClickedEvent" == method) {
         widget.listener?.onAdClickedCallback(AppLovinMAX.createAd(adUnitId, arguments));
       } else if ("OnAdViewAdExpandedEvent" == method) {


### PR DESCRIPTION
Add support for ad waterfall. 

Printed from iOS:

```
{
   "networkResponses":[
      {
         "mediatedNetwork":{
            "adapterVersion":11.5.5,
            "name":"AppLovin",
            "sdkVersion":11.5.5,
            "adapterClassName":"ALAppLovinMediationAdapter"
         },
         "latencyMillis":25,
         "adLoadState":1,
         "credentials":{
            "placement_id":"banner_regular"
         }
      }
   ],
   "latencyMillis":26,
   "name":"Default Waterfall",
   "testName":"Control"
}
```

Banner error:

`2022-11-30 15:18:46.805667+0900 Runner[6797:2304032] flutter: Banner ad failed to load: [MaxError code: 204, message: MAX returned no eligible ads from any mediated networks for this app/device., waterfall: {networkResponses: [], latencyMillis: 1, name: Default Waterfall, testName: Control}]
`

An example in the doc:

```
    AppLovinMAX.setBannerListener(AdViewAdListener(onAdLoadedCallback: (ad) {
      print('Waterfall Name: ${ad.waterfall['name']} and Test Name: ${ad.waterfall['testName']}');
      print('Waterfall latency was: ${ad.waterfall['latencyMillis']} milliseconds');
      ad.waterfall['networkResponses'].forEach((networkResponse) {
          var mediatedNetwork = networkResponse['mediatedNetwork'];
          print('Network adapterClassName: ${mediatedNetwork['adapterClassName']} '
            'name: ${mediatedNetwork['name']} '
            'sdkVersion: ${mediatedNetwork['sdkVersion']} '
            'adapterVersion: ${mediatedNetwork['adapterVersion']}');
          print('adLoadState: ${networkResponse['adLoadState']}');
          print('latencyMillis: ${networkResponse['latencyMillis']}');
          print('credentials: ${networkResponse['credentials']['placement_id']}');
          var error = networkResponse['error'];
          if (error != null) {
            print('error code: ${error['code']} message: ${error['message']}');
          }
      });
    }
```