### PR TITLE
fix/pass_placement_when_creating_max_ad_view

### DIFF
--- a/applovin_max/lib/src/max_ad_view.dart
+++ b/applovin_max/lib/src/max_ad_view.dart
@@ -97,7 +97,8 @@ class _MaxAdViewState extends State<MaxAdView> {
             creationParams: <String, dynamic>{
               "ad_unit_id": widget.adUnitId,
               "ad_format": widget.adFormat.value,
-              "is_auto_refresh_enabled": widget.isAutoRefreshEnabled
+              "is_auto_refresh_enabled": widget.isAutoRefreshEnabled,
+              "placement": widget.placement,
             },
             creationParamsCodec: const StandardMessageCodec(),
             onPlatformViewCreated: _onMaxAdViewCreated,
@@ -115,7 +116,8 @@ class _MaxAdViewState extends State<MaxAdView> {
             creationParams: <String, dynamic>{
               "ad_unit_id": widget.adUnitId,
               "ad_format": widget.adFormat.value,
-              "is_auto_refresh_enabled": widget.isAutoRefreshEnabled
+              "is_auto_refresh_enabled": widget.isAutoRefreshEnabled,
+              "placement": widget.placement,
             },
             creationParamsCodec: const StandardMessageCodec(),
             onPlatformViewCreated: _onMaxAdViewCreated,


### PR DESCRIPTION
Currently we don't pass `placement` parameter when creating `MaxAdView`

https://github.com/AppLovin/AppLovin-MAX-Flutter/blob/c6d19695e2218bae3dbbbab07477bd71faca171b/applovin_max/lib/src/max_ad_view.dart#L100

https://github.com/AppLovin/AppLovin-MAX-Flutter/blob/c6d19695e2218bae3dbbbab07477bd71faca171b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdViewFactory.java#L54
https://github.com/AppLovin/AppLovin-MAX-Flutter/blob/c6d19695e2218bae3dbbbab07477bd71faca171b/applovin_max/ios/Classes/AppLovinMAXAdViewFactory.m#L52