### PR TITLE
fix: onAdLoadFailedCallback event not received

### DIFF
--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
@@ -813,16 +813,7 @@ public class AppLovinMAX
 
     public void fireErrorCallback(final String name, final String adUnitId, final MaxError error)
     {
-        try
-        {
-            Map<String, Object> params = new HashMap<>( 5 );
-            params.put( "adUnitId", adUnitId );
-            params.put( "errorCode", error.getCode() );
-            params.put( "errorMessage", error.getMessage() );
-            params.put( "waterfall", createAdWaterfallInfo( error.getWaterfall() ) );
-            fireCallback( name, params );
-        }
-        catch ( Throwable ignored ) { }
+        fireErrorCallback(name, adUnitId, error, sharedChannel);
     }
 
     @Override

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
@@ -797,6 +797,20 @@ public class AppLovinMAX
         AppLovinMAX.getInstance().fireErrorCallback( name, adUnitId, error );
     }
 
+    public void fireErrorCallback(final String name, final String adUnitId, final MaxError error, final MethodChannel channel)
+    {
+        try
+        {
+            Map<String, Object> params = new HashMap<>( 5 );
+            params.put( "adUnitId", adUnitId );
+            params.put( "errorCode", error.getCode() );
+            params.put( "errorMessage", error.getMessage() );
+            params.put( "waterfall", createAdWaterfallInfo( error.getWaterfall() ) );
+            fireCallback( name, params, channel );
+        }
+        catch ( Throwable ignored ) { }
+    }
+
     public void fireErrorCallback(final String name, final String adUnitId, final MaxError error)
     {
         try

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdView.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdView.java
@@ -116,7 +116,7 @@ public class AppLovinMAXAdView
     @Override
     public void onAdLoadFailed(final String adUnitId, final MaxError error)
     {
-        AppLovinMAX.getInstance().fireErrorCallback( "OnAdViewAdLoadFailedEvent", adUnitId, error );
+        AppLovinMAX.getInstance().fireErrorCallback( "OnAdViewAdLoadFailedEvent", adUnitId, error, channel );
     }
 
     @Override

--- a/applovin_max/ios/Classes/AppLovinMAX.h
+++ b/applovin_max/ios/Classes/AppLovinMAX.h
@@ -30,6 +30,12 @@
  */
 - (void)sendErrorEventWithName:(NSString *)name forAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(MAError *)error;
 
+/**
+ * Utility method for sending error events through the Flutter channel into Dart.
+ */
+- (void)sendErrorEventWithName:(NSString *)name forAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(MAError *)error channel:(FlutterMethodChannel *)channel;
+
+
 + (void)log:(NSString *)format, ...;
 
 @end

--- a/applovin_max/ios/Classes/AppLovinMAX.m
+++ b/applovin_max/ios/Classes/AppLovinMAX.m
@@ -757,6 +757,16 @@ static FlutterMethodChannel *ALSharedChannel;
     [self sendEventWithName: name body: body];
 }
 
+- (void)sendErrorEventWithName:(NSString *)name forAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(MAError *)error channel:(FlutterMethodChannel *)channel
+{
+    NSDictionary *body = @{@"adUnitId": adUnitIdentifier,
+                           @"errorCode" : @(error.code),
+                           @"errorMessage" : error.message,
+                           @"waterfall": [self createAdWaterfallInfo: error.waterfall]};
+
+    [self sendEventWithName: name body: body channel: channel];
+}
+
 - (void)didClickAd:(MAAd *)ad
 {
     NSString *name;

--- a/applovin_max/ios/Classes/AppLovinMAXAdView.m
+++ b/applovin_max/ios/Classes/AppLovinMAXAdView.m
@@ -93,7 +93,9 @@
 {
     [[AppLovinMAX shared] sendErrorEventWithName: @"OnAdViewAdLoadFailedEvent"
                              forAdUnitIdentifier: adUnitIdentifier
-                                       withError: error];
+                                       withError: error
+                                       channel: self.channel
+                                       ];
 }
 
 - (void)didClickAd:(MAAd *)ad


### PR DESCRIPTION
resolve #62 

MaxAdView uses its own [method channel](https://github.com/AppLovin/AppLovin-MAX-Flutter/blob/d2223c7579442c8453f5defab875a500da9c84b4/applovin_max/lib/src/max_ad_view.dart#L135). Error events should also be passed through that method channel. Currently, we cannot receive the `OnAdViewAdLoadFailedEvent` because it uses the shared method channel('applovin_max') to pass error events.

https://github.com/AppLovin/AppLovin-MAX-Flutter/blob/d2223c7579442c8453f5defab875a500da9c84b4/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdView.java#L119

https://github.com/AppLovin/AppLovin-MAX-Flutter/blob/d2223c7579442c8453f5defab875a500da9c84b4/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java#L800