### PR TITLE
fix/mintegral_native_ads

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix black screen in mintegral native ads
 ## 3.0.1
 * Fix native ad app icon not rendering on Android.
 ## 3.0.0

--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Fix black screen in mintegral native ads
+* Fix blank views for Mintegral native ads.
 ## 3.0.1
 * Fix native ad app icon not rendering on Android.
 ## 3.0.0

--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Fix blank views for Mintegral native ads.
+* Fix blank media views for Mintegral native ads.
 ## 3.0.1
 * Fix native ad app icon not rendering on Android.
 ## 3.0.0

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
@@ -435,10 +435,10 @@ public class AppLovinMAXNativeAdView
 
         if ( mediaView.getParent() == null )
         {
-            RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams( rect.width(), rect.height() );
-            params.addRule( RelativeLayout.ALIGN_PARENT_TOP, RelativeLayout.TRUE );
-            params.addRule( RelativeLayout.ALIGN_PARENT_LEFT, RelativeLayout.TRUE );
-            mediaViewContainer.addView( mediaView, params );
+            RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(
+                    RelativeLayout.LayoutParams.MATCH_PARENT,
+                    RelativeLayout.LayoutParams.MATCH_PARENT );
+            mediaViewContainer.addView( mediaView, layoutParams );
         }
         else
         {

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
@@ -11,6 +11,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
+import android.widget.RelativeLayout;
 
 import com.applovin.mediation.MaxAd;
 import com.applovin.mediation.MaxAdRevenueListener;
@@ -68,21 +69,21 @@ public class AppLovinMAXNativeAdView
     @Nullable
     private final String customData;
 
-    private final FrameLayout nativeAdView;
+    private final FrameLayout    nativeAdView;
     @Nullable
-    private       View        titleView;
+    private       View           titleView;
     @Nullable
-    private       View        advertiserView;
+    private       View           advertiserView;
     @Nullable
-    private       View        bodyView;
+    private       View           bodyView;
     @Nullable
-    private       View        callToActionView;
+    private       View           callToActionView;
     @Nullable
-    private       ImageView   iconView;
+    private       ImageView      iconView;
     @Nullable
-    private       FrameLayout optionsViewContainer;
+    private       FrameLayout    optionsViewContainer;
     @Nullable
-    private       FrameLayout mediaViewContainer;
+    private       RelativeLayout mediaViewContainer;
 
     private final List<View> clickableViews = new ArrayList<>();
 
@@ -423,22 +424,29 @@ public class AppLovinMAXNativeAdView
 
         if ( mediaViewContainer == null )
         {
-            mediaViewContainer = new FrameLayout( context );
+            mediaViewContainer = new RelativeLayout( context );
             // Sets an identifier for the Google adapters to verify the view in the tree
             mediaViewContainer.setId( MEDIA_VIEW_CONTAINER_TAG );
             mediaViewContainer.setTag( MEDIA_VIEW_CONTAINER_TAG );
             nativeAdView.addView( mediaViewContainer );
         }
 
+        Rect rect = getRect( call );
+
         if ( mediaView.getParent() == null )
         {
-            mediaViewContainer.addView( mediaView );
-
-            mediaView.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
-            mediaView.getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
+            RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams( rect.width(), rect.height() );
+            params.addRule( RelativeLayout.ALIGN_PARENT_TOP, RelativeLayout.TRUE );
+            params.addRule( RelativeLayout.ALIGN_PARENT_LEFT, RelativeLayout.TRUE );
+            mediaViewContainer.addView( mediaView, params );
+        }
+        else
+        {
+            mediaView.getLayoutParams().width = rect.width();
+            mediaView.getLayoutParams().height = rect.height();
         }
 
-        updateViewLayout( nativeAdView, mediaViewContainer, getRect( call ) );
+        updateViewLayout( nativeAdView, mediaViewContainer, rect );
     }
 
     private void renderAd()

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
@@ -440,11 +440,6 @@ public class AppLovinMAXNativeAdView
                     RelativeLayout.LayoutParams.MATCH_PARENT );
             mediaViewContainer.addView( mediaView, layoutParams );
         }
-        else
-        {
-            mediaView.getLayoutParams().width = rect.width();
-            mediaView.getLayoutParams().height = rect.height();
-        }
 
         updateViewLayout( nativeAdView, mediaViewContainer, rect );
     }


### PR DESCRIPTION
Fix black screen in mintegral native ads using RelativeLayout instead of FrameLayout as a container of mediaView.

Verified to work with: 
- Google AdMob
- Mintegral
- Line
- Pangle
- InMobi