### PR TITLE
Fixed LateInitializationError on accessing a late variable in didChan…

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Fixed LateInitializationError on accessing a late variable in didChangeDependencies().
+* Fixed `LateInitializationError` when building native ad widget. Fixes https://github.com/AppLovin/AppLovin-MAX-Flutter/issues/113.
 ## 3.1.1
 * Depends on Android SDK v11.11.2 and iOS SDK v11.11.2.
 ## 3.1.0

--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fixed LateInitializationError on accessing a late variable in didChangeDependencies().
 ## 3.1.1
 * Depends on Android SDK v11.11.2 and iOS SDK v11.11.2.
 ## 3.1.0

--- a/applovin_max/lib/src/max_native_ad_view.dart
+++ b/applovin_max/lib/src/max_native_ad_view.dart
@@ -91,9 +91,6 @@ class MaxNativeAdView extends StatefulWidget {
 class _MaxNativeAdViewState extends State<MaxNativeAdView> {
   final GlobalKey _nativeAdViewKey = GlobalKey();
 
-  // The number of device pixels for each logical pixel.
-  late final double _devicePixelRatio;
-
   // Unique [MethodChannel] to this [MaxNativeAdView] instance.
   MethodChannel? _methodChannel;
 
@@ -120,15 +117,6 @@ class _MaxNativeAdViewState extends State<MaxNativeAdView> {
   void dispose() {
     widget.controller!.removeListener(_handleControllerChanged);
     super.dispose();
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (defaultTargetPlatform == TargetPlatform.android) {
-      MediaQueryData queryData = MediaQuery.of(context);
-      _devicePixelRatio = queryData.devicePixelRatio;
-    }
   }
 
   @override
@@ -233,11 +221,12 @@ class _MaxNativeAdViewState extends State<MaxNativeAdView> {
     if (key == null) return;
     Rect rect = _getViewSize(key, _nativeAdViewKey);
     if (defaultTargetPlatform == TargetPlatform.android) {
+      double devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
       _methodChannel!.invokeMethod(method, <String, dynamic>{
-        'x': (rect.left * _devicePixelRatio).round(),
-        'y': (rect.top * _devicePixelRatio).round(),
-        'width': (rect.width * _devicePixelRatio).round(),
-        'height': (rect.height * _devicePixelRatio).round(),
+        'x': (rect.left * devicePixelRatio).round(),
+        'y': (rect.top * devicePixelRatio).round(),
+        'width': (rect.width * devicePixelRatio).round(),
+        'height': (rect.height * devicePixelRatio).round(),
       });
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       _methodChannel!.invokeMethod(method, <String, dynamic>{


### PR DESCRIPTION
Fixed `LateInitializationError` on accessing a late variable of `devicePixelRatio` in `didChageDependencies()`.

https://github.com/AppLovin/AppLovin-MAX-Flutter/issues/113

`didChageDependencies()` can be called multiple times, but we are trying to initialize a late variable in the function, which causes the error.

Since `MediaQuery.devicePixelRatioOf()` is a static method to return a value, the variable is now retrieved just before the use.