### PR TITLE
ref/add_support_for_adaptive_banners

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Versions
 
+## x.x.x
+* Add support for widget adaptive banners via `MaxAdView(extraParameters: {"adaptive_banner": "true"}, ... )`.
 ## 3.1.2
-* Fixed `LateInitializationError` when building native ad widget. Fixes https://github.com/AppLovin/AppLovin-MAX-Flutter/issues/113.
+* Fix `LateInitializationError` when building native ad widget. Fixes https://github.com/AppLovin/AppLovin-MAX-Flutter/issues/113.
 ## 3.1.1
 * Depends on Android SDK v11.11.2 and iOS SDK v11.11.2.
 ## 3.1.0

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
@@ -594,6 +594,11 @@ public class AppLovinMAX
         destroyAdView( adUnitId, getDeviceSpecificBannerAdViewAdFormat() );
     }
 
+    public void getAdaptiveBannerHeightForWidth(final double width, final Result result)
+    {
+        result.success( (double) getDeviceSpecificBannerAdViewAdFormat().getAdaptiveSize( (int) width, applicationContext ).getHeight() );
+    }
+
     // MRECS
 
     public void createMRec(final String adUnitId, final String mrecPosition)
@@ -1819,6 +1824,11 @@ public class AppLovinMAX
             destroyBanner( adUnitId );
 
             result.success( null );
+        }
+        else if ( "getAdaptiveBannerHeightForWidth".equals( call.method ) )
+        {
+            double width = call.argument( "width" );
+            getAdaptiveBannerHeightForWidth( width, result );
         }
         else if ( "createMRec".equals( call.method ) )
         {

--- a/applovin_max/ios/Classes/AppLovinMAX.m
+++ b/applovin_max/ios/Classes/AppLovinMAX.m
@@ -547,6 +547,11 @@ static FlutterMethodChannel *ALSharedChannel;
     [self destroyAdViewWithAdUnitIdentifier: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT];
 }
 
+- (void)getAdaptiveBannerHeightForWidth:(CGFloat)width andNotify:(FlutterResult)result
+{
+    result(@([DEVICE_SPECIFIC_ADVIEW_AD_FORMAT adaptiveSizeForWidth: width].height));
+}
+
 #pragma mark - MRECs
 
 - (void)createMRecForAdUnitIdentifier:(NSString *)adUnitIdentifier position:(NSString *)position
@@ -1727,6 +1732,11 @@ static FlutterMethodChannel *ALSharedChannel;
         [self destroyBannerForAdUnitIdentifier: adUnitId];
         
         result(nil);
+    }
+    else if ( [@"getAdaptiveBannerHeightForWidth" isEqualToString: call.method] )
+    {
+        NSNumber *width = call.arguments[@"width"];
+        [self getAdaptiveBannerHeightForWidth: [width doubleValue] andNotify: result];
     }
     else if ( [@"createMRec" isEqualToString: call.method] )
     {

--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -412,6 +412,13 @@ class AppLovinMAX {
     });
   }
 
+  /// Gets the adaptive banner size for the provided width.
+  static Future<double?> getAdaptiveBannerHeightForWidth(double width) {
+    return channel.invokeMethod('getAdaptiveBannerHeightForWidth', {
+        'width': width,
+    });
+  }
+
   //
   // MRECs
   //


### PR DESCRIPTION
Add support for adaptive banners.  Issues #81 and #117.

`adaptiveBannerWidth` is added since `MaxAdView` does not support the users to specify the widget size, but we can enable that with the regular size properties of `width` and `height`.