### PR TITLE
bug/use_generic_mediaquery_for_devicepixelratio

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Replace `MediaQuery.devicePixelRatioOf` with `MediaQuery.of().devicePixelRatio`.
+* Replace `MediaQuery.devicePixelRatioOf` with `MediaQuery.of().devicePixelRatio`. https://github.com/AppLovin/AppLovin-MAX-Flutter/issues/120
 ## 3.2.0
 * Add support for widget adaptive banners via `MaxAdView(extraParameters: {"adaptive_banner": "true"}, ... )`.
 ## 3.1.2

--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Replace `MediaQuery.devicePixelRatioOf` with `MediaQuery.of().devicePixelRatio`.
 ## 3.2.0
 * Add support for widget adaptive banners via `MaxAdView(extraParameters: {"adaptive_banner": "true"}, ... )`.
 ## 3.1.2

--- a/applovin_max/lib/src/max_native_ad_view.dart
+++ b/applovin_max/lib/src/max_native_ad_view.dart
@@ -221,7 +221,7 @@ class _MaxNativeAdViewState extends State<MaxNativeAdView> {
     if (key == null) return;
     Rect rect = _getViewSize(key, _nativeAdViewKey);
     if (defaultTargetPlatform == TargetPlatform.android) {
-      double devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+      double devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
       _methodChannel!.invokeMethod(method, <String, dynamic>{
         'x': (rect.left * devicePixelRatio).round(),
         'y': (rect.top * devicePixelRatio).round(),


### PR DESCRIPTION
Issue #120.

`MediaQuery.devicePixelRatioOf` is available only after the Flutter version 3.13.3, so some pubs may need to upgrade their Flutter version.   Instead, use `MediaQuery.of().devicePixelRatio`. 