### PR TITLE
add revenuePrecision to MaxAd

### DIFF
--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
@@ -1478,6 +1478,7 @@ public class AppLovinMAX
         adInfo.put( "networkName", ad.getNetworkName() );
         adInfo.put( "placement", !TextUtils.isEmpty( ad.getPlacement() ) ? ad.getPlacement() : "" );
         adInfo.put( "revenue", ad.getRevenue() );
+        adInfo.put( "revenuePrecision", ad.getRevenuePrecision() );
         adInfo.put( "dspName", !TextUtils.isEmpty( ad.getDspName() ) ? ad.getDspName() : "" );
         adInfo.put( "waterfall", createAdWaterfallInfo( ad.getWaterfall() ) );
 

--- a/applovin_max/ios/Classes/AppLovinMAX.m
+++ b/applovin_max/ios/Classes/AppLovinMAX.m
@@ -1422,6 +1422,7 @@ static FlutterMethodChannel *ALSharedChannel;
              @"networkName" : ad.networkName,
              @"placement" : ad.placement ?: @"",
              @"revenue" : @(ad.revenue),
+             @"revenuePrecision" : ad.revenuePrecision,
              @"dspName" : ad.DSPName ?: @"",
              @"waterfall": [self createAdWaterfallInfo: ad.waterfall]};
 }

--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -144,6 +144,7 @@ class AppLovinMAX {
       adUnitId,
       arguments["networkName"],
       arguments["revenue"],
+      arguments["revenuePrecision"],
       arguments["creativeId"],
       arguments["dspName"],
       arguments["placement"],

--- a/applovin_max/lib/src/ad_classes.dart
+++ b/applovin_max/lib/src/ad_classes.dart
@@ -9,6 +9,9 @@ class MaxAd {
   /// The ad’s revenue amount, or 0 if no revenue amount exists.
   final double revenue;
 
+  /// The precision of the revenue as defined in the docs. possible values: 'publisher_defined', 'exact', 'estimated', 'undefined', ''
+  final String revenuePrecision;
+
   /// The creative ID tied to the ad, if any. You can report creative issues to the corresponding ad network using this ID.
   final String creativeId;
 
@@ -25,11 +28,11 @@ class MaxAd {
   final MaxNativeAd? nativeAd;
 
   /// @nodoc
-  MaxAd(this.adUnitId, this.networkName, this.revenue, this.creativeId, this.dspName, this.placement, this.waterfall, this.nativeAd);
+  MaxAd(this.adUnitId, this.networkName, this.revenue, this.revenuePrecision, this.creativeId, this.dspName, this.placement, this.waterfall, this.nativeAd);
 
   @override
   String toString() {
-    return '[MaxAd adUnitId: $adUnitId, networkName: $networkName, revenue: $revenue, dspName: $dspName, creativeId: $creativeId, placement: $placement, waterfall: $waterfall, nativeAd: $nativeAd]';
+    return '[MaxAd adUnitId: $adUnitId, networkName: $networkName, revenue: $revenue, revenuePrecision: $revenuePrecision, dspName: $dspName, creativeId: $creativeId, placement: $placement, waterfall: $waterfall, nativeAd: $nativeAd]';
   }
 }
 


### PR DESCRIPTION
This patch adds revenuePrecision to MaxAd structure using the documented getRevenuePrecision API.

I'd appreciate it if you could add it to your main branch.

Thanks