### PR TITLE
fix/starrating_not_converting_on_ios

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Fix `starRating` not correctly converting from platform on iOS.
 * Add APIs for Selective Init. For more info, check out our [docs](https://dash.applovin.com/documentation/mediation/flutter/getting-started/advanced-settings#selective-init).
 * Add support for Terms and Privacy Policy Flow. For more info, check out our [docs](https://dash.applovin.com/documentation/mediation/flutter/getting-started/terms-and-privacy-policy-flow).
 * Depends on Android SDK v12.0.0 and iOS SDK v12.0.0.

--- a/applovin_max/lib/src/ad_classes.dart
+++ b/applovin_max/lib/src/ad_classes.dart
@@ -107,8 +107,8 @@ class MaxNativeAd {
         advertiser = json['advertiser'],
         body = json['body'],
         callToAction = json['callToAction'],
-        starRating = json['starRating'],
-        mediaContentAspectRatio = json['mediaContentAspectRatio'],
+        starRating = double.tryParse(json['starRating'].toString()),
+        mediaContentAspectRatio = double.tryParse(json['mediaContentAspectRatio'].toString()),
         isIconImageAvailable = (json['isIconImageAvailable'].runtimeType == int) ? (json['isIconImageAvailable'] == 1) : json['isIconImageAvailable'],
         isOptionsViewAvailable = (json['isOptionsViewAvailable'].runtimeType == int) ? (json['isOptionsViewAvailable'] == 1) : json['isOptionsViewAvailable'],
         isMediaViewAvailable = (json['isMediaViewAvailable'].runtimeType == int) ? (json['isMediaViewAvailable'] == 1) : json['isMediaViewAvailable'];


### PR DESCRIPTION
Fix `starRating` not correctly converting from platform on iOS.

`starRating` in iOS is NSNumber.  When it comes to the Flutter side, it is okay when it is an integer or a small number of digits in float, such as 4 or 4.5, but when it is like 4.123456, the conversion fails, then causes a silent exception.

Use `double.tryParse()`, so that it returns null when it can't be converted.   Do the same for `mediaContentAspectRatio` just in case.