### PR TITLE
ref/allow_setmuted_before_sdk_init

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Allow calling `setMuted()` before SDK is initialized.
 * Depends on Android SDK v12.1.0 and iOS SDK v12.1.0.
 ## 3.4.0
 * Add support for Selective Init. For more info, check out our [docs](https://dash.applovin.com/documentation/mediation/flutter/getting-started/advanced-settings#selective-init).

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
@@ -87,6 +87,7 @@ public class AppLovinMAX
     // Store these values if pub attempts to set it before initializing
     private       List<String>        initializationAdUnitIdsToSet;
     private       String              userIdToSet;
+    private       Boolean             mutedToSet;
     private       List<String>        testDeviceAdvertisingIdsToSet;
     private       Boolean             verboseLoggingToSet;
     private       Boolean             creativeDebuggerEnabledToSet;
@@ -242,6 +243,12 @@ public class AppLovinMAX
         {
             settings.getTermsAndPrivacyPolicyFlowSettings().setDebugUserGeography( getAppLovinConsentFlowUserGeography( debugUserGeographyToSet ) );
             debugUserGeographyToSet = null;
+        }
+
+        if ( mutedToSet != null )
+        {
+            settings.setMuted( mutedToSet );
+            mutedToSet = null;
         }
 
         if ( testDeviceAdvertisingIdsToSet != null )
@@ -431,9 +438,15 @@ public class AppLovinMAX
 
     public void setMuted(final boolean muted)
     {
-        if ( !isPluginInitialized ) return;
-
-        sdk.getSettings().setMuted( muted );
+        if ( isPluginInitialized )
+        {
+            sdk.getSettings().setMuted( muted );
+            mutedToSet = null;
+        }
+        else
+        {
+            mutedToSet = muted;
+        }
     }
 
     public boolean isMuted()

--- a/applovin_max/ios/Classes/AppLovinMAX.m
+++ b/applovin_max/ios/Classes/AppLovinMAX.m
@@ -24,6 +24,7 @@
 // Store these values if pub attempts to set it before initializing
 @property (nonatomic, strong, nullable) NSArray<NSString *> *initializationAdUnitIdentifiersToSet;
 @property (nonatomic,   copy, nullable) NSString *userIdentifierToSet;
+@property (nonatomic, strong, nullable) NSNumber *mutedToSet;
 @property (nonatomic, strong, nullable) NSArray<NSString *> *testDeviceIdentifiersToSet;
 @property (nonatomic, strong, nullable) NSNumber *verboseLoggingToSet;
 @property (nonatomic, strong, nullable) NSNumber *creativeDebuggerEnabledToSet;
@@ -201,6 +202,12 @@ static FlutterMethodChannel *ALSharedChannel;
         self.debugUserGeographyToSet = nil;
     }
     
+    if ( self.mutedToSet )
+    {
+        settings.muted = self.mutedToSet;
+        self.mutedToSet = nil;
+    }
+
     if ( self.testDeviceIdentifiersToSet )
     {
         settings.testDeviceAdvertisingIdentifiers = self.testDeviceIdentifiersToSet;
@@ -392,9 +399,15 @@ static FlutterMethodChannel *ALSharedChannel;
 
 - (void)setMuted:(BOOL)muted
 {
-    if ( ![self isPluginInitialized] ) return;
-    
-    self.sdk.settings.muted = muted;
+    if ( [self isPluginInitialized] )
+    {
+        self.sdk.settings.muted = muted;
+        self.mutedToSet = nil;
+    }
+    else
+    {
+        self.mutedToSet = @(muted);
+    }
 }
 
 - (void)setVerboseLogging:(BOOL)enabled


### PR DESCRIPTION
Allow calling setMuted() before SDK is initialized ([ticket](https://app.asana.com/0/573104092700345/1206102448675921/f)).