### PR TITLE
ref/showCmpForExistingUser

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Update `AppLovinMAX.showCmpForExistingUser()` to return `CmpError` instead of `int` raw value.
 * Add support for Amazon bidding for rewarded ads.
 ## 3.5.0
 * Add support for showing Google UMP to existing users for integrations using our Google UMP Automation feature. For more info, check out our [docs](https://dash.applovin.com/documentation/mediation/flutter/getting-started/terms-and-privacy-policy-flow#showing-gdpr-flow-to-existing-users).

--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -356,9 +356,11 @@ class AppLovinMAX {
   /// Note that this resets the user’s existing consent information.
   ///
   /// The function returns when the flow finishes showing. On success, returns
-  /// null. On failure, returns one of the [CmpError] codes.
-  static Future<int?> showCmpForExistingUser() {
-    return channel.invokeMethod('showCmpForExistingUser');
+  /// null. On failure, returns [CmpError].
+  static Future<CmpError?> showCmpForExistingUser() async {
+    int? error = await channel.invokeMethod('showCmpForExistingUser') as int;
+    if (error == null) return null;
+    return CmpError.values.firstWhere((v) => v.value == error);
   }
 
   /// Returns true if a supported CMP SDK is detected.


### PR DESCRIPTION
To be consistent with the other PR for MaxConfiguration, it should return an Enum value instead of its raw value.

```
CmpError? error = await AppLovinMAX.showCmpForExistingUser();
if (error != null) {
    print("showCmpForExistingUser: $error");
}

==> I/flutter (17004): showCmpForExistingUser: CmpError.unspecified
```