### PR TITLE
fix/npe_on_accessing_getNativeAd

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Fix NPE for accessing a null native ad on Android.
 * Update `AppLovinMAX.showCmpForExistingUser()` to return `CmpError` instead of `int` raw value.
 * Add `MaxConfiguration` to encapsulate a return object of `AppLovinMAX.initialize(...)`.
 * Add support for Amazon bidding for rewarded ads.

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
@@ -304,6 +304,8 @@ public class AppLovinMAXNativeAdView
 
     private void addTitleView(final MethodCall call, final MaxAd ad)
     {
+        if ( ad == null ) return;
+
         if ( ad.getNativeAd().getTitle() == null ) return;
 
         if ( titleView == null )
@@ -320,6 +322,8 @@ public class AppLovinMAXNativeAdView
 
     private void addAdvertiserView(final MethodCall call, final MaxAd ad)
     {
+        if ( ad == null ) return;
+
         if ( ad.getNativeAd().getAdvertiser() == null ) return;
 
         if ( advertiserView == null )
@@ -336,6 +340,8 @@ public class AppLovinMAXNativeAdView
 
     private void addBodyView(final MethodCall call, final MaxAd ad)
     {
+        if ( ad == null ) return;
+
         if ( ad.getNativeAd().getBody() == null ) return;
 
         if ( bodyView == null )
@@ -352,6 +358,8 @@ public class AppLovinMAXNativeAdView
 
     private void addCallToActionView(final MethodCall call, final MaxAd ad)
     {
+        if ( ad == null ) return;
+
         if ( ad.getNativeAd().getCallToAction() == null ) return;
 
         if ( callToActionView == null )
@@ -368,6 +376,8 @@ public class AppLovinMAXNativeAdView
 
     private void addIconView(final MethodCall call, final MaxAd ad)
     {
+        if ( ad == null ) return;
+
         MaxNativeAd.MaxNativeAdImage icon = ad.getNativeAd().getIcon();
 
         if ( icon == null )
@@ -403,6 +413,8 @@ public class AppLovinMAXNativeAdView
 
     private void addOptionsView(final MethodCall call, final MaxAd ad)
     {
+        if ( ad == null ) return;
+
         View optionsView = ad.getNativeAd().getOptionsView();
         if ( optionsView == null ) return;
 
@@ -425,6 +437,8 @@ public class AppLovinMAXNativeAdView
 
     private void addMediaView(final MethodCall call, final MaxAd ad)
     {
+        if ( ad == null ) return;
+
         View mediaView = ad.getNativeAd().getMediaView();
         if ( mediaView == null ) return;
 
@@ -452,7 +466,7 @@ public class AppLovinMAXNativeAdView
 
     private void renderAd(final MaxAd ad)
     {
-        if ( adLoader != null )
+        if ( ad != null && adLoader != null )
         {
             adLoader.a( clickableViews, nativeAdView, ad );
             adLoader.b( ad );

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
@@ -101,70 +101,44 @@ public class AppLovinMAXNativeAdView
         channel = new MethodChannel( messenger, uniqueChannelName );
         channel.setMethodCallHandler( (call, result) -> {
 
-            MaxAd currentNativeAd = nativeAd;
-
             if ( "addTitleView".equals( call.method ) )
             {
-                if ( currentNativeAd != null )
-                {
-                    addTitleView( call, currentNativeAd );
-                }
+                if ( nativeAd != null ) addTitleView( call, nativeAd );
                 result.success( null );
             }
             else if ( "addAdvertiserView".equals( call.method ) )
             {
-                if ( currentNativeAd != null )
-                {
-                    addAdvertiserView( call, currentNativeAd );
-                }
+                if ( nativeAd != null ) addAdvertiserView( call, nativeAd );
                 result.success( null );
             }
             else if ( "addBodyView".equals( call.method ) )
             {
-                if ( currentNativeAd != null )
-                {
-                    addBodyView( call, currentNativeAd );
-                }
+                if ( nativeAd != null ) addBodyView( call, nativeAd );
                 result.success( null );
             }
             else if ( "addCallToActionView".equals( call.method ) )
             {
-                if ( currentNativeAd != null )
-                {
-                    addCallToActionView( call, currentNativeAd );
-                }
+                if ( nativeAd != null ) addCallToActionView( call, nativeAd );
                 result.success( null );
             }
             else if ( "addIconView".equals( call.method ) )
             {
-                if ( currentNativeAd != null )
-                {
-                    addIconView( call, currentNativeAd );
-                }
+                if ( nativeAd != null ) addIconView( call, nativeAd );
                 result.success( null );
             }
             else if ( "addOptionsView".equals( call.method ) )
             {
-                if ( currentNativeAd != null )
-                {
-                    addOptionsView( call, currentNativeAd );
-                }
+                if ( nativeAd != null ) addOptionsView( call, nativeAd );
                 result.success( null );
             }
             else if ( "addMediaView".equals( call.method ) )
             {
-                if ( currentNativeAd != null )
-                {
-                    addMediaView( call, currentNativeAd );
-                }
+                if ( nativeAd != null ) addMediaView( call, nativeAd );
                 result.success( null );
             }
             else if ( "renderAd".equals( call.method ) )
             {
-                if ( currentNativeAd != null )
-                {
-                    renderAd( currentNativeAd );
-                }
+                if ( nativeAd != null ) renderAd( nativeAd );
                 result.success( null );
             }
             else if ( "loadAd".equals( call.method ) )

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
@@ -103,42 +103,42 @@ public class AppLovinMAXNativeAdView
 
             if ( "addTitleView".equals( call.method ) )
             {
-                addTitleView( call );
+                if ( nativeAd != null ) addTitleView( call, nativeAd );
                 result.success( null );
             }
             else if ( "addAdvertiserView".equals( call.method ) )
             {
-                addAdvertiserView( call );
+                if ( nativeAd != null ) addAdvertiserView( call, nativeAd );
                 result.success( null );
             }
             else if ( "addBodyView".equals( call.method ) )
             {
-                addBodyView( call );
+                if ( nativeAd != null ) addBodyView( call, nativeAd );
                 result.success( null );
             }
             else if ( "addCallToActionView".equals( call.method ) )
             {
-                addCallToActionView( call );
+                if ( nativeAd != null ) addCallToActionView( call, nativeAd );
                 result.success( null );
             }
             else if ( "addIconView".equals( call.method ) )
             {
-                addIconView( call );
+                if ( nativeAd != null ) addIconView( call, nativeAd );
                 result.success( null );
             }
             else if ( "addOptionsView".equals( call.method ) )
             {
-                addOptionsView( call );
+                if ( nativeAd != null ) addOptionsView( call, nativeAd );
                 result.success( null );
             }
             else if ( "addMediaView".equals( call.method ) )
             {
-                addMediaView( call );
+                if ( nativeAd != null ) addMediaView( call, nativeAd );
                 result.success( null );
             }
             else if ( "renderAd".equals( call.method ) )
             {
-                renderAd();
+                if ( nativeAd != null ) renderAd( nativeAd );
                 result.success( null );
             }
             else if ( "loadAd".equals( call.method ) )
@@ -302,11 +302,9 @@ public class AppLovinMAXNativeAdView
 
     /// Native Ad Component Methods
 
-    private void addTitleView(final MethodCall call)
+    private void addTitleView(final MethodCall call, final MaxAd ad)
     {
-        if ( nativeAd == null ) return;
-
-        if ( nativeAd.getNativeAd().getTitle() == null ) return;
+        if ( ad.getNativeAd().getTitle() == null ) return;
 
         if ( titleView == null )
         {
@@ -320,11 +318,9 @@ public class AppLovinMAXNativeAdView
         updateViewLayout( nativeAdView, titleView, getRect( call ) );
     }
 
-    private void addAdvertiserView(final MethodCall call)
+    private void addAdvertiserView(final MethodCall call, final MaxAd ad)
     {
-        if ( nativeAd == null ) return;
-
-        if ( nativeAd.getNativeAd().getAdvertiser() == null ) return;
+        if ( ad.getNativeAd().getAdvertiser() == null ) return;
 
         if ( advertiserView == null )
         {
@@ -338,11 +334,9 @@ public class AppLovinMAXNativeAdView
         updateViewLayout( nativeAdView, advertiserView, getRect( call ) );
     }
 
-    private void addBodyView(final MethodCall call)
+    private void addBodyView(final MethodCall call, final MaxAd ad)
     {
-        if ( nativeAd == null ) return;
-
-        if ( nativeAd.getNativeAd().getBody() == null ) return;
+        if ( ad.getNativeAd().getBody() == null ) return;
 
         if ( bodyView == null )
         {
@@ -356,11 +350,9 @@ public class AppLovinMAXNativeAdView
         updateViewLayout( nativeAdView, bodyView, getRect( call ) );
     }
 
-    private void addCallToActionView(final MethodCall call)
+    private void addCallToActionView(final MethodCall call, final MaxAd ad)
     {
-        if ( nativeAd == null ) return;
-
-        if ( nativeAd.getNativeAd().getCallToAction() == null ) return;
+        if ( ad.getNativeAd().getCallToAction() == null ) return;
 
         if ( callToActionView == null )
         {
@@ -374,11 +366,9 @@ public class AppLovinMAXNativeAdView
         updateViewLayout( nativeAdView, callToActionView, getRect( call ) );
     }
 
-    private void addIconView(final MethodCall call)
+    private void addIconView(final MethodCall call, final MaxAd ad)
     {
-        if ( nativeAd == null ) return;
-
-        MaxNativeAd.MaxNativeAdImage icon = nativeAd.getNativeAd().getIcon();
+        MaxNativeAd.MaxNativeAdImage icon = ad.getNativeAd().getIcon();
 
         if ( icon == null )
         {
@@ -411,11 +401,9 @@ public class AppLovinMAXNativeAdView
         }
     }
 
-    private void addOptionsView(final MethodCall call)
+    private void addOptionsView(final MethodCall call, final MaxAd ad)
     {
-        if ( nativeAd == null ) return;
-
-        View optionsView = nativeAd.getNativeAd().getOptionsView();
+        View optionsView = ad.getNativeAd().getOptionsView();
         if ( optionsView == null ) return;
 
         if ( optionsViewContainer == null )
@@ -435,11 +423,9 @@ public class AppLovinMAXNativeAdView
         updateViewLayout( nativeAdView, optionsViewContainer, getRect( call ) );
     }
 
-    private void addMediaView(final MethodCall call)
+    private void addMediaView(final MethodCall call, final MaxAd ad)
     {
-        if ( nativeAd == null ) return;
-
-        View mediaView = nativeAd.getNativeAd().getMediaView();
+        View mediaView = ad.getNativeAd().getMediaView();
         if ( mediaView == null ) return;
 
         if ( mediaViewContainer == null )
@@ -464,12 +450,12 @@ public class AppLovinMAXNativeAdView
         updateViewLayout( nativeAdView, mediaViewContainer, rect );
     }
 
-    private void renderAd()
+    private void renderAd(final MaxAd ad)
     {
-        if ( adLoader != null && nativeAd != null )
+        if ( adLoader != null )
         {
-            adLoader.a( clickableViews, nativeAdView, nativeAd );
-            adLoader.b( nativeAd );
+            adLoader.a( clickableViews, nativeAdView, ad );
+            adLoader.b( ad );
         }
         else
         {

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
@@ -101,44 +101,70 @@ public class AppLovinMAXNativeAdView
         channel = new MethodChannel( messenger, uniqueChannelName );
         channel.setMethodCallHandler( (call, result) -> {
 
+            MaxAd currentNativeAd = nativeAd;
+
             if ( "addTitleView".equals( call.method ) )
             {
-                if ( nativeAd != null ) addTitleView( call, nativeAd );
+                if ( currentNativeAd != null )
+                {
+                    addTitleView( call, currentNativeAd );
+                }
                 result.success( null );
             }
             else if ( "addAdvertiserView".equals( call.method ) )
             {
-                if ( nativeAd != null ) addAdvertiserView( call, nativeAd );
+                if ( currentNativeAd != null )
+                {
+                    addAdvertiserView( call, currentNativeAd );
+                }
                 result.success( null );
             }
             else if ( "addBodyView".equals( call.method ) )
             {
-                if ( nativeAd != null ) addBodyView( call, nativeAd );
+                if ( currentNativeAd != null )
+                {
+                    addBodyView( call, currentNativeAd );
+                }
                 result.success( null );
             }
             else if ( "addCallToActionView".equals( call.method ) )
             {
-                if ( nativeAd != null ) addCallToActionView( call, nativeAd );
+                if ( currentNativeAd != null )
+                {
+                    addCallToActionView( call, currentNativeAd );
+                }
                 result.success( null );
             }
             else if ( "addIconView".equals( call.method ) )
             {
-                if ( nativeAd != null ) addIconView( call, nativeAd );
+                if ( currentNativeAd != null )
+                {
+                    addIconView( call, currentNativeAd );
+                }
                 result.success( null );
             }
             else if ( "addOptionsView".equals( call.method ) )
             {
-                if ( nativeAd != null ) addOptionsView( call, nativeAd );
+                if ( currentNativeAd != null )
+                {
+                    addOptionsView( call, currentNativeAd );
+                }
                 result.success( null );
             }
             else if ( "addMediaView".equals( call.method ) )
             {
-                if ( nativeAd != null ) addMediaView( call, nativeAd );
+                if ( currentNativeAd != null )
+                {
+                    addMediaView( call, currentNativeAd );
+                }
                 result.success( null );
             }
             else if ( "renderAd".equals( call.method ) )
             {
-                if ( nativeAd != null ) renderAd( nativeAd );
+                if ( currentNativeAd != null )
+                {
+                    renderAd( currentNativeAd );
+                }
                 result.success( null );
             }
             else if ( "loadAd".equals( call.method ) )

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
@@ -304,6 +304,8 @@ public class AppLovinMAXNativeAdView
 
     private void addTitleView(final MethodCall call)
     {
+        if ( nativeAd == null ) return;
+
         if ( nativeAd.getNativeAd().getTitle() == null ) return;
 
         if ( titleView == null )
@@ -320,6 +322,8 @@ public class AppLovinMAXNativeAdView
 
     private void addAdvertiserView(final MethodCall call)
     {
+        if ( nativeAd == null ) return;
+
         if ( nativeAd.getNativeAd().getAdvertiser() == null ) return;
 
         if ( advertiserView == null )
@@ -336,6 +340,8 @@ public class AppLovinMAXNativeAdView
 
     private void addBodyView(final MethodCall call)
     {
+        if ( nativeAd == null ) return;
+
         if ( nativeAd.getNativeAd().getBody() == null ) return;
 
         if ( bodyView == null )
@@ -352,6 +358,8 @@ public class AppLovinMAXNativeAdView
 
     private void addCallToActionView(final MethodCall call)
     {
+        if ( nativeAd == null ) return;
+
         if ( nativeAd.getNativeAd().getCallToAction() == null ) return;
 
         if ( callToActionView == null )
@@ -368,6 +376,8 @@ public class AppLovinMAXNativeAdView
 
     private void addIconView(final MethodCall call)
     {
+        if ( nativeAd == null ) return;
+
         MaxNativeAd.MaxNativeAdImage icon = nativeAd.getNativeAd().getIcon();
 
         if ( icon == null )
@@ -456,7 +466,7 @@ public class AppLovinMAXNativeAdView
 
     private void renderAd()
     {
-        if ( adLoader != null )
+        if ( adLoader != null && nativeAd != null )
         {
             adLoader.a( clickableViews, nativeAdView, nativeAd );
             adLoader.b( nativeAd );


### PR DESCRIPTION
Fix #166 - NPE when accessing `com.applovin.mediation.MaxAd.getNativeAd()`.    The native adView must have been destroyed as soon as a native ad is loaded but before it is applied to all the asset views.

```
io.flutter.plugins.firebase.crashlytics.FlutterError - PlatformException(error, Attempt to invoke interface method 'com.applovin.mediation.nativeAds.MaxNativeAd com.applovin.mediation.MaxAd.getNativeAd()' on a null object reference, null, java.lang.NullPointerException: Attempt to invoke interface method'
package:flutter/src/services/message_codecs.dart:652
```

