### PR TITLE
fix/linter_warnings

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix linter warnings.
 ## 3.6.0
 * Fix NPE for accessing a null native ad on Android.
 * Update `AppLovinMAX.showCmpForExistingUser()` to return `CmpError` instead of `int` raw value.

--- a/applovin_max/analysis_options.yaml
+++ b/applovin_max/analysis_options.yaml
@@ -2,3 +2,8 @@ include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options
+
+analyzer:
+  errors:
+    # allow self-reference to deprecated members
+    deprecated_member_use_from_same_package: ignore

--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -360,7 +360,7 @@ class AppLovinMAX {
   /// The function returns when the flow finishes showing. On success, returns
   /// null. On failure, returns [CmpError].
   static Future<CmpError?> showCmpForExistingUser() async {
-    int? error = await channel.invokeMethod('showCmpForExistingUser') as int;
+    int? error = await channel.invokeMethod('showCmpForExistingUser') as int?;
     if (error == null) return null;
     return CmpError.values.firstWhere((v) => v.value == error);
   }

--- a/applovin_max/lib/src/ad_classes.dart
+++ b/applovin_max/lib/src/ad_classes.dart
@@ -170,7 +170,7 @@ class MaxConfiguration {
   MaxConfiguration.fromJson(Map<String, dynamic> json)
       : consentDialogState = ConsentDialogState.values[json['consentDialogState']],
         countryCode = json['countryCode'],
-        isTestModeEnabled = bool.tryParse(json['isTestModeEnabled'].toString()),
+        isTestModeEnabled = json['isTestModeEnabled'],
         consentFlowUserGeography = (json['consentFlowUserGeography'] is String)
             ? ConsentFlowUserGeography.values.firstWhere((v) => v.value == json['consentFlowUserGeography'])
             : null,

--- a/applovin_max/lib/src/max_ad_view.dart
+++ b/applovin_max/lib/src/max_ad_view.dart
@@ -244,8 +244,8 @@ class _MaxAdViewState extends State<MaxAdView> {
   }
 
   bool _isTablet() {
-    final double devicePixelRatio = ui.window.devicePixelRatio;
-    final ui.Size size = ui.window.physicalSize;
+    final double devicePixelRatio = ui.PlatformDispatcher.instance.views.first.devicePixelRatio;
+    final ui.Size size = ui.PlatformDispatcher.instance.views.first.physicalSize;
     final double width = size.width;
     final double height = size.height;
 


### PR DESCRIPTION
Fix linter warnings.

```
$ dart analyze  lib
Analyzing lib...                       1.0s

warning • applovin_max.dart:364:15 • The operand can't be null, so the condition is always 'false'. Try removing the condition, an enclosing condition, or the
          whole conditional statement. • unnecessary_null_comparison
warning • src/ad_classes.dart:173:34 • This API is available since SDK 3.0.0, but constraints '>=2.17.1 <3.0.0' don't guarantee it. Try updating the SDK
          constraints. • sdk_version_since
   info • src/ad_classes.dart:167:34 • 'ConsentDialogState' is deprecated and shouldn't be used. Use ConsentFlowUserGeography instead. Try replacing the use of
          the deprecated member with the replacement. • deprecated_member_use_from_same_package
   info • src/ad_classes.dart:171:9 • 'consentDialogState' is deprecated and shouldn't be used. Use ConsentFlowUserGeography instead. Try replacing the use of
          the deprecated member with the replacement. • deprecated_member_use_from_same_package
   info • src/ad_classes.dart:171:30 • 'ConsentDialogState' is deprecated and shouldn't be used. Use ConsentFlowUserGeography instead. Try replacing the use of
          the deprecated member with the replacement. • deprecated_member_use_from_same_package
   info • src/ad_classes.dart:181:52 • 'consentDialogState' is deprecated and shouldn't be used. Use ConsentFlowUserGeography instead. Try replacing the use of
          the deprecated member with the replacement. • deprecated_member_use_from_same_package
   info • src/max_ad_view.dart:247:40 • 'window' is deprecated and shouldn't be used. Look up the current FlutterView from the context via View.of(context) or
          consult the PlatformDispatcher directly instead. Deprecated to prepare for the upcoming multi-window support. This feature was deprecated after
          v3.7.0-32.0.pre. Try replacing the use of the deprecated member with the replacement. • deprecated_member_use
   info • src/max_ad_view.dart:248:29 • 'window' is deprecated and shouldn't be used. Look up the current FlutterView from the context via View.of(context) or
          consult the PlatformDispatcher directly instead. Deprecated to prepare for the upcoming multi-window support. This feature was deprecated after
          v3.7.0-32.0.pre. Try replacing the use of the deprecated member with the replacement. • deprecated_member_use

8 issues found.
```