### PR TITLE
fix/NPE_for_accessing_methodChannel

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Fix NPE for accessing a null methodChannel in MaxAdView. https://github.com/AppLovin/AppLovin-MAX-Flutter/issues/176
 * Fix linter warnings.
 ## 3.6.0
 * Fix NPE for accessing a null native ad on Android.

--- a/applovin_max/lib/src/max_ad_view.dart
+++ b/applovin_max/lib/src/max_ad_view.dart
@@ -105,9 +105,9 @@ class _MaxAdViewState extends State<MaxAdView> {
 
     if (oldWidget.isAutoRefreshEnabled != widget.isAutoRefreshEnabled) {
       if (widget.isAutoRefreshEnabled) {
-        _methodChannel!.invokeMethod('startAutoRefresh');
+        _methodChannel?.invokeMethod('startAutoRefresh');
       } else {
-        _methodChannel!.invokeMethod('stopAutoRefresh');
+        _methodChannel?.invokeMethod('stopAutoRefresh');
       }
     }
   }


### PR DESCRIPTION
Fix NPE for accessing a null methodChannel in MaxAdView. #176 

`_methodChannel` is created asynchronously in the `build()` which is executed before `didUpdateWidget()` where the null error is generated.   The actual creation of `_methodChannel` might happen later than `didUpdateWidget()`.