### PR TITLE
fix/2nd_initialize_not_return

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Fix not to return from the 2nd call of `AppLovinMAX.initialize()`.
+* Update `AppLovinMAX.initialize()` to return a `Future` on hot restart.
 ## 3.10.0
 * Depends on Android SDK v12.5.0 and iOS SDK v12.5.0.
 ## 3.9.2

--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix not to return from the 2nd call of `AppLovinMAX.initialize()`.
 ## 3.10.0
 * Depends on Android SDK v12.5.0 and iOS SDK v12.5.0.
 ## 3.9.2

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
@@ -340,6 +340,11 @@ public class AppLovinMAX
         } );
     }
 
+    private void getMaxConfiguration(final Result result)
+    {
+        result.success( getInitializationMessage() );
+    }
+
     private Map<String, Object> getInitializationMessage()
     {
         Map<String, Object> message = new HashMap<>( 4 );
@@ -1940,6 +1945,10 @@ public class AppLovinMAX
         else if ( "isInitialized".equals( call.method ) )
         {
             isInitialized( result );
+        }
+        else if ( "getMaxConfiguration".equals( call.method ) )
+        {
+            getMaxConfiguration( result );
         }
         else if ( "isTablet".equals( call.method ) )
         {

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
@@ -340,7 +340,7 @@ public class AppLovinMAX
         } );
     }
 
-    private void getMaxConfiguration(final Result result)
+    private void getConfiguration(final Result result)
     {
         result.success( getInitializationMessage() );
     }
@@ -1946,9 +1946,9 @@ public class AppLovinMAX
         {
             isInitialized( result );
         }
-        else if ( "getMaxConfiguration".equals( call.method ) )
+        else if ( "getConfiguration".equals( call.method ) )
         {
-            getMaxConfiguration( result );
+            getConfiguration( result );
         }
         else if ( "isTablet".equals( call.method ) )
         {

--- a/applovin_max/ios/Classes/AppLovinMAX.m
+++ b/applovin_max/ios/Classes/AppLovinMAX.m
@@ -299,7 +299,7 @@ static FlutterMethodChannel *ALSharedChannel;
     }];
 }
 
-- (void)getMaxConfiguration:(FlutterResult)result
+- (void)getConfiguration:(FlutterResult)result
 {
     result([self initializationMessage]);
 }
@@ -1871,9 +1871,9 @@ static FlutterMethodChannel *ALSharedChannel;
     {
         [self isInitialized: result];
     }
-    else if ( [@"getMaxConfiguration" isEqualToString: call.method] )
+    else if ( [@"getConfiguration" isEqualToString: call.method] )
     {
-        [self getMaxConfiguration: result];
+        [self getConfiguration: result];
     }
     else if ( [@"isTablet" isEqualToString: call.method] )
     {

--- a/applovin_max/ios/Classes/AppLovinMAX.m
+++ b/applovin_max/ios/Classes/AppLovinMAX.m
@@ -299,6 +299,11 @@ static FlutterMethodChannel *ALSharedChannel;
     }];
 }
 
+- (void)getMaxConfiguration:(FlutterResult)result
+{
+    result([self initializationMessage]);
+}
+
 - (NSDictionary<NSString *, id> *)initializationMessage
 {
     NSMutableDictionary<NSString *, id> *message = [NSMutableDictionary dictionaryWithCapacity: 5];
@@ -1865,6 +1870,10 @@ static FlutterMethodChannel *ALSharedChannel;
     else if ( [@"isInitialized" isEqualToString: call.method] )
     {
         [self isInitialized: result];
+    }
+    else if ( [@"getMaxConfiguration" isEqualToString: call.method] )
+    {
+        [self getMaxConfiguration: result];
     }
     else if ( [@"isTablet" isEqualToString: call.method] )
     {

--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -43,9 +43,9 @@ class AppLovinMAX {
   /// See [this GitHub issue](https://github.com/AppLovin/AppLovin-MAX-Flutter/issues/210)
   /// for more details on why calling `initialize` multiple times can lead to issues.
   static Future<MaxConfiguration?> initialize(String sdkKey) async {
-    bool? isPlatformSDKInitialized = await isInitialized();
-    if (isPlatformSDKInitialized ?? false) {
-      Map conf = await channel.invokeMethod('getMaxConfiguration');
+    bool isPlatformSDKInitialized = await isInitialized() ?? false;
+    if (isPlatformSDKInitialized) {
+      Map conf = await channel.invokeMethod('getConfiguration');
       return MaxConfiguration.fromJson(Map<String, dynamic>.from(conf));
     }
 

--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -43,6 +43,12 @@ class AppLovinMAX {
   /// See [this GitHub issue](https://github.com/AppLovin/AppLovin-MAX-Flutter/issues/210)
   /// for more details on why calling `initialize` multiple times can lead to issues.
   static Future<MaxConfiguration?> initialize(String sdkKey) async {
+    bool? isPlatformSDKInitialized = await isInitialized();
+    if (isPlatformSDKInitialized ?? false) {
+      Map conf = await channel.invokeMethod('getMaxConfiguration');
+      return MaxConfiguration.fromJson(Map<String, dynamic>.from(conf));
+    }
+
     channel.setMethodCallHandler((MethodCall call) async {
       var method = call.method;
       var arguments = call.arguments;

--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:applovin_max/src/ad_classes.dart';
 import 'package:applovin_max/src/ad_listeners.dart';
 import 'package:applovin_max/src/enums.dart';
@@ -19,6 +21,9 @@ class AppLovinMAX {
   /// @nodoc
   static MethodChannel channel = const MethodChannel('applovin_max');
 
+  static bool _hasInitializeInvoked = false;
+  static final Completer<MaxConfiguration> _initializeCompleter = Completer<MaxConfiguration>();
+
   /// The targeting data object for you to provide user or app data that will improve how we target ads.
   static final TargetingData targetingData = TargetingData(channel);
 
@@ -39,14 +44,23 @@ class AppLovinMAX {
   /// cause the returned future to never complete.
   ///
   /// For more information, see the [Initialize the SDK](https://developers.applovin.com/en/flutter/overview/integration).
-  /// 
+  ///
   /// See [this GitHub issue](https://github.com/AppLovin/AppLovin-MAX-Flutter/issues/210)
   /// for more details on why calling `initialize` multiple times can lead to issues.
   static Future<MaxConfiguration?> initialize(String sdkKey) async {
+    if (_hasInitializeInvoked) {
+      // Return a future object even when the actual value is not ready.
+      return _initializeCompleter.future;
+    }
+
+    _hasInitializeInvoked = true;
+
+    // isInitialized() returns true when Flutter is performing hot restart
     bool isPlatformSDKInitialized = await isInitialized() ?? false;
     if (isPlatformSDKInitialized) {
       Map conf = await channel.invokeMethod('getConfiguration');
-      return MaxConfiguration.fromJson(Map<String, dynamic>.from(conf));
+      _initializeCompleter.complete(MaxConfiguration.fromJson(Map<String, dynamic>.from(conf)));
+      return _initializeCompleter.future;
     }
 
     channel.setMethodCallHandler((MethodCall call) async {
@@ -143,7 +157,9 @@ class AppLovinMAX {
       'sdk_key': sdkKey,
     }) as Map;
 
-    return MaxConfiguration.fromJson(Map<String, dynamic>.from(conf));
+    _initializeCompleter.complete(MaxConfiguration.fromJson(Map<String, dynamic>.from(conf)));
+
+    return _initializeCompleter.future;
   }
 
   /// @nodoc


### PR DESCRIPTION
Fix not to return from the 2nd call of `AppLovinMAX.initialize()` (#212).    `AppLovinMAXisInitialized()` allows us to check whether the SDK is initialized or not, even during hot reloading.