### PR TITLE
revert/ref/update_example_for_initialization

### DIFF
--- a/applovin_max/example/lib/main.dart
+++ b/applovin_max/example/lib/main.dart
@@ -10,6 +10,20 @@ import 'scrolled_adview.dart';
 
 enum AdLoadState { notLoaded, loading, loaded }
 
+void main() {
+  runApp(const MaterialApp(
+    title: 'AppLovin MAX Demo',
+    home: MyApp(),
+  ));
+}
+
+class MyApp extends StatefulWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
 // Create constants
 const String _sdkKey = "YOUR_SDK_KEY";
 
@@ -18,31 +32,6 @@ final String _rewardedAdUnitId = Platform.isAndroid ? "ANDROID_REWARDED_AD_UNIT_
 final String _bannerAdUnitId = Platform.isAndroid ? "ANDROID_BANNER_AD_UNIT_ID" : "IOS_BANNER_AD_UNIT_ID";
 final String _mrecAdUnitId = Platform.isAndroid ? "ANDROID_MREC_AD_UNIT_ID" : "IOS_MREC_AD_UNIT_ID";
 final String _nativeAdUnitId = Platform.isAndroid ? "ANDROID_NATIVE_AD_UNIT_ID" : "IOS_NATIVE_AD_UNIT_ID";
-
-void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-
-  // MAX Consent Flow - https://developers.applovin.com/en/flutter/overview/terms-and-privacy-policy-flow
-  AppLovinMAX.setTermsAndPrivacyPolicyFlowEnabled(true);
-  AppLovinMAX.setPrivacyPolicyUrl("https://your_company_name.com/privacy");
-  AppLovinMAX.setTermsOfServiceUrl("https://your_company_name.com/terms");
-
-  MaxConfiguration? conf = await AppLovinMAX.initialize(_sdkKey);
-
-  runApp(MaterialApp(
-    title: 'AppLovin MAX Demo',
-    home: MyApp(configuration: conf),
-  ));
-}
-
-class MyApp extends StatefulWidget {
-  final MaxConfiguration? configuration;
-
-  const MyApp({Key? key, this.configuration}) : super(key: key);
-
-  @override
-  State<MyApp> createState() => _MyAppState();
-}
 
 const int _maxExponentialRetryCount = 6;
 
@@ -65,10 +54,24 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
+    initializePlugin();
+  }
 
-    if (widget.configuration != null) {
+  // NOTE: Platform messages are asynchronous, so we initialize in an async method.
+  Future<void> initializePlugin() async {
+    logStatus("Initializing SDK...");
+
+    // MAX Consent Flow - https://developers.applovin.com/en/flutter/overview/terms-and-privacy-policy-flow
+    AppLovinMAX.setTermsAndPrivacyPolicyFlowEnabled(true);
+    AppLovinMAX.setPrivacyPolicyUrl("https://your_company_name.com/privacy");
+    AppLovinMAX.setTermsOfServiceUrl("https://your_company_name.com/terms");
+
+    MaxConfiguration? configuration = await AppLovinMAX.initialize(_sdkKey);
+    if (configuration != null) {
       _isInitialized = true;
-      logStatus("SDK Initialized: ${widget.configuration?.countryCode}");
+
+      logStatus("SDK Initialized: ${configuration.countryCode}");
+
       attachAdListeners();
     }
   }


### PR DESCRIPTION
Revert:

 ref/update_example_for_initialization (#221)

Running the MAX initialization before `runApp()` will not work on Android devices, as it may need to pop up a menu for user consent.
