### PR TITLE
fix/null_check_operator_on_null_value_in_dispose_maxnativeadview

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Fix `Null check operator used on a null value` on `MaxNativeAdView.dispose()`.
+* Fix `Null check operator used on a null value` warning in `MaxNativeAdView.dispose()`.
 ## 3.10.1
 * Update `AppLovinMAX.initialize()` to return a `Future` on hot restart.
 ## 3.10.0

--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix `Null check operator used on a null value` on `MaxNativeAdView.dispose()`.
 ## 3.10.1
 * Update `AppLovinMAX.initialize()` to return a `Future` on hot restart.
 ## 3.10.0

--- a/applovin_max/lib/src/max_native_ad_view.dart
+++ b/applovin_max/lib/src/max_native_ad_view.dart
@@ -115,7 +115,7 @@ class _MaxNativeAdViewState extends State<MaxNativeAdView> {
 
   @override
   void dispose() {
-    widget.controller!.removeListener(_handleControllerChanged);
+    widget.controller?.removeListener(_handleControllerChanged);
     super.dispose();
   }
 


### PR DESCRIPTION
Fix `Null check operator used on a null value` on `MaxNativeAdView.dispose()`.  (#226)

