### PR TITLE
Make InterstitialListener nullable (Fixes #261)

### DIFF
--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -558,7 +558,7 @@ class AppLovinMAX {
   //
 
   /// Sets an [InterstitialListener] listener with which you can receive notifications about ad events.
-  static void setInterstitialListener(InterstitialListener listener) {
+  static void setInterstitialListener(InterstitialListener? listener) {
     _interstitialListener = listener;
   }
 


### PR DESCRIPTION
Currently there is no way to remove `InterstitialListener` once set. Make parameter `null`able so that it can be unset by passing `null` to it.

https://github.com/AppLovin/AppLovin-MAX-Flutter/blob/b9fee8f3ce1d974c293e3b4ba78ef4980e054974/applovin_max/lib/applovin_max.dart#L561