### PR TITLE
ref/add_support_for_yandex_native_ads

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Add support for Yandex native ads.
 * Update listener APIs to allow for null values for unsetting.
 ## 4.0.0
 * Depends on Android SDK v13.0.0 and iOS SDK v13.0.0.

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXNativeAdView.java
@@ -310,7 +310,7 @@ public class AppLovinMAXNativeAdView
 
         if ( titleView == null )
         {
-            titleView = new View( context );
+            titleView = new FrameLayout( context );
             titleView.setTag( TITLE_LABEL_TAG );
             nativeAdView.addView( titleView );
         }
@@ -328,7 +328,7 @@ public class AppLovinMAXNativeAdView
 
         if ( advertiserView == null )
         {
-            advertiserView = new View( context );
+            advertiserView = new FrameLayout( context );
             advertiserView.setTag( ADVERTISER_VIEW_TAG );
             nativeAdView.addView( advertiserView );
         }
@@ -346,7 +346,7 @@ public class AppLovinMAXNativeAdView
 
         if ( bodyView == null )
         {
-            bodyView = new View( context );
+            bodyView = new FrameLayout( context );
             bodyView.setTag( BODY_VIEW_TAG );
             nativeAdView.addView( bodyView );
         }
@@ -364,7 +364,7 @@ public class AppLovinMAXNativeAdView
 
         if ( callToActionView == null )
         {
-            callToActionView = new View( context );
+            callToActionView = new FrameLayout( context );
             callToActionView.setTag( CALL_TO_ACTION_VIEW_TAG );
             nativeAdView.addView( callToActionView );
         }

--- a/applovin_max/lib/src/max_native_ad_view.dart
+++ b/applovin_max/lib/src/max_native_ad_view.dart
@@ -188,7 +188,7 @@ class _MaxNativeAdViewState extends State<MaxNativeAdView> {
         _updateAllAssetViews();
 
         // Register clickable views and initiate the rendering of the native ad on the platform.
-        await _methodChannel?.invokeMethod("renderAd");
+        _renderAd();
 
         // Update the Flutter asset views with the native ad
         setState(() {
@@ -249,6 +249,10 @@ class _MaxNativeAdViewState extends State<MaxNativeAdView> {
     _methodChannel?.invokeMethod(method, params);
   }
 
+  void _renderAd() {
+    _methodChannel?.invokeMethod("renderAd");
+  }
+
   // Returns the frame (rect) size relative to the parent's position
   Rect _getViewSize(GlobalKey key, GlobalKey parentKey) {
     RenderBox? renderedObject = key.currentContext?.findRenderObject() as RenderBox?;
@@ -297,6 +301,7 @@ class MaxNativeAdTitleView extends StatelessWidget {
       onNotification: (SizeChangedLayoutNotification notification) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _NativeAdViewScope.of(context)._updateAssetView(_NativeAdViewScope.of(context)._titleViewKey, "addTitleView");
+          _NativeAdViewScope.of(context)._renderAd();
         });
         return false;
       },
@@ -352,6 +357,7 @@ class MaxNativeAdAdvertiserView extends StatelessWidget {
       onNotification: (SizeChangedLayoutNotification notification) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _NativeAdViewScope.of(context)._updateAssetView(_NativeAdViewScope.of(context)._advertiserViewKey, "addAdvertiserView");
+          _NativeAdViewScope.of(context)._renderAd();
         });
         return false;
       },
@@ -407,6 +413,7 @@ class MaxNativeAdBodyView extends StatelessWidget {
       onNotification: (SizeChangedLayoutNotification notification) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _NativeAdViewScope.of(context)._updateAssetView(_NativeAdViewScope.of(context)._bodyViewKey, "addBodyView");
+          _NativeAdViewScope.of(context)._renderAd();
         });
         return false;
       },
@@ -444,6 +451,7 @@ class MaxNativeAdCallToActionView extends StatelessWidget {
       onNotification: (SizeChangedLayoutNotification notification) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _NativeAdViewScope.of(context)._updateAssetView(_NativeAdViewScope.of(context)._callToActionViewKey, "addCallToActionView");
+          _NativeAdViewScope.of(context)._renderAd();
         });
         return false;
       },
@@ -484,6 +492,7 @@ class MaxNativeAdIconView extends StatelessWidget {
       onNotification: (SizeChangedLayoutNotification notification) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _NativeAdViewScope.of(context)._updateAssetView(_NativeAdViewScope.of(context)._iconViewKey, "addIconView");
+          _NativeAdViewScope.of(context)._renderAd();
         });
         return false;
       },
@@ -523,6 +532,7 @@ class MaxNativeAdOptionsView extends StatelessWidget {
       onNotification: (SizeChangedLayoutNotification notification) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _NativeAdViewScope.of(context)._updateAssetView(_NativeAdViewScope.of(context)._optionsViewKey, "addOptionsView");
+          _NativeAdViewScope.of(context)._renderAd();
         });
         return false;
       },
@@ -563,6 +573,7 @@ class MaxNativeAdMediaView extends StatelessWidget {
       onNotification: (SizeChangedLayoutNotification notification) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _NativeAdViewScope.of(context)._updateAssetView(_NativeAdViewScope.of(context)._mediaViewKey, "addMediaView");
+          _NativeAdViewScope.of(context)._renderAd();
         });
         return false;
       },


### PR DESCRIPTION
Add support for Yandex native ads.   Tested with the following networks to verify that nothing is broken:

- Google AdMob
- Line
- InMobi
- Vungle
- Mintegral
- Pangle