### PR TITLE
ref/suspend_auto_refresh_for_preloaded_adview_in_background

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+##
+* Update preloaded banners and MRECs (`MaxAdView`) to suspend auto-refresh while not visible in background.
 ## 4.0.2
 * Update IconView to support native ad icon image view, primarily for BigoAds native ads.
 ## 4.0.1

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdView.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdView.java
@@ -172,7 +172,11 @@ public class AppLovinMAXAdView
 
             AppLovinMAXAdViewWidget preloadedWidget = preloadedWidgetInstances.get( widget.getAdView().getAdUnitId() );
 
-            if ( widget != preloadedWidget )
+            if ( widget == preloadedWidget )
+            {
+                widget.setAutoRefresh( false );
+            }
+            else
             {
                 widgetInstances.remove( widget.getAdView().getAdUnitId() );
                 widget.destroy();

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdViewWidget.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdViewWidget.java
@@ -42,6 +42,8 @@ class AppLovinMAXAdViewWidget
 
         // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
         adView.setExtraParameter( "allow_pause_auto_refresh_immediately", "true" );
+
+        adView.stopAutoRefresh();
     }
 
     public MaxAdView getAdView()

--- a/applovin_max/ios/Classes/AppLovinMAXAdView.m
+++ b/applovin_max/ios/Classes/AppLovinMAXAdView.m
@@ -163,7 +163,11 @@ static NSMutableDictionary<NSString *, AppLovinMAXAdViewWidget *> *preloadedWidg
     
     AppLovinMAXAdViewWidget *preloadedWidget = preloadedWidgetInstances[self.widget.adView.adUnitIdentifier];
     
-    if ( self.widget != preloadedWidget )
+    if ( self.widget == preloadedWidget )
+    {
+        self.widget.autoRefresh = NO;
+    }
+    else
     {
         [widgetInstances removeObjectForKey: self.widget.adView.adUnitIdentifier];
         [self.widget destroy];

--- a/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
+++ b/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
@@ -32,6 +32,8 @@
         // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
         [self.adView setExtraParameterForKey: @"allow_pause_auto_refresh_immediately" value: @"true"];
         
+        [self.adView stopAutoRefresh];
+
         // Set a frame size to suppress an error of zero area for MAAdView
         self.adView.frame = (CGRect) { CGPointZero, adFormat.size };
     }


### PR DESCRIPTION
Update preloaded banners and MRECs to suspend auto-refresh while not visible in background

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update preloaded ad banners and MRECs (`MaxAdView`) to suspend the auto-refresh feature when they are not visible in the background in both Android and iOS implementations.

### Why are these changes being made?

This change addresses a behavior where preloaded ad views were continuing to auto-refresh even when not visible, leading to unnecessary resource consumption and potential application performance issues. The approach taken is to explicitly stop the auto-refresh in both Android and iOS setups, leveraging an SDK workaround parameter to ensure the calls to stop refreshing are respected immediately. This change optimizes resource usage by preventing redundant ad fetches when ads are not in view.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->