### PR TITLE
feat/add_support_for_preloading_multiple_adview

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
-##
+## x.x.x
+* Enhance banner and MREC (`MaxAdView`) preloading to support preloading multiple `MaxAdView` instances.
 * Update preloaded banners and MRECs (`MaxAdView`) to suspend auto-refresh while not visible in background.
 ## 4.0.2
 * Update IconView to support native ad icon image view, primarily for BigoAds native ads.

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
@@ -61,8 +61,8 @@ import io.flutter.plugin.common.MethodChannel.Result;
 public class AppLovinMAX
         implements FlutterPlugin, MethodCallHandler, ActivityAware, MaxAdListener, MaxAdViewAdListener, MaxRewardedAdListener, MaxAdRevenueListener
 {
-    private static final String SDK_TAG = "AppLovinSdk";
-    public static final  String TAG     = "AppLovinMAX";
+    private static final String SDK_TAG        = "AppLovinSdk";
+    public static final  String TAG            = "AppLovinMAX";
     private static final String PLUGIN_VERSION = "4.0.2";
 
     private static final String USER_GEOGRAPHY_GDPR    = "G";
@@ -1992,8 +1992,8 @@ public class AppLovinMAX
         }
         else if ( "destroyWidgetAdView".equals( call.method ) )
         {
-            String adUnitId = call.argument( "ad_unit_id" );
-            AppLovinMAXAdView.destroyWidgetAdView( adUnitId, result );
+            Integer adViewId = call.argument( "ad_view_id" );
+            AppLovinMAXAdView.destroyWidgetAdView( adViewId, result );
         }
         else if ( "addSegment".equals( call.method ) )
         {

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdViewFactory.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdViewFactory.java
@@ -42,15 +42,15 @@ public class AppLovinMAXAdViewFactory
         String adFormatStr = (String) params.get( "ad_format" );
         MaxAdFormat adFormat = "mrec".equals( adFormatStr ) ? MaxAdFormat.MREC : AppLovinMAX.getDeviceSpecificBannerAdViewAdFormat( context );
 
-        AppLovinMAX.d( "Creating MaxAdView widget with Ad Unit ID: " + adUnitId );
-
         // Optional params
+        Integer ad_view_id = params.containsKey( "ad_view_id" ) ? (Integer) params.get( "ad_view_id" ) : null;
+        int adViewId = ad_view_id != null ? ad_view_id : 0;
         boolean isAutoRefreshEnabled = Boolean.TRUE.equals( params.get( "is_auto_refresh_enabled" ) ); // Defaults to true
         String placement = params.containsKey( "placement" ) ? (String) params.get( "placement" ) : null;
         String customData = params.containsKey( "custom_data" ) ? (String) params.get( "custom_data" ) : null;
         Map<String, Object> extraParameters = params.containsKey( "extra_parameters" ) ? (Map<String, Object>) params.get( "extra_parameters" ) : null;
         Map<String, Object> localExtraParameters = params.containsKey( "local_extra_parameters" ) ? (Map<String, Object>) params.get( "local_extra_parameters" ) : null;
 
-        return new AppLovinMAXAdView( viewId, adUnitId, adFormat, isAutoRefreshEnabled, placement, customData, extraParameters, localExtraParameters, messenger, sdk, context );
+        return new AppLovinMAXAdView( viewId, adUnitId, adViewId, adFormat, isAutoRefreshEnabled, placement, customData, extraParameters, localExtraParameters, messenger, sdk, context );
     }
 }

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdViewWidget.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdViewWidget.java
@@ -51,6 +51,11 @@ class AppLovinMAXAdViewWidget
         return adView;
     }
 
+    public String getAdUnitId()
+    {
+        return adView.getAdUnitId();
+    }
+
     public void setPlacement(@Nullable final String value)
     {
         adView.setPlacement( value );
@@ -61,7 +66,7 @@ class AppLovinMAXAdViewWidget
         adView.setCustomData( value );
     }
 
-    public void setAutoRefresh(final boolean enabled)
+    public void setAutoRefreshEnabled(final boolean enabled)
     {
         if ( enabled )
         {
@@ -126,6 +131,7 @@ class AppLovinMAXAdViewWidget
     public void onAdLoaded(@NonNull final MaxAd ad)
     {
         Map<String, Object> params = AppLovinMAX.getInstance().getAdInfo( ad );
+        params.put( "adViewId", hashCode() );
 
         if ( shouldPreloadWidget )
         {
@@ -144,6 +150,7 @@ class AppLovinMAXAdViewWidget
     public void onAdLoadFailed(@NonNull final String adUnitId, @NonNull final MaxError error)
     {
         Map<String, Object> params = AppLovinMAX.getInstance().getAdLoadFailedInfo( adUnitId, error );
+        params.put( "adViewId", hashCode() );
 
         if ( shouldPreloadWidget )
         {
@@ -164,6 +171,8 @@ class AppLovinMAXAdViewWidget
         if ( containerView != null )
         {
             Map<String, Object> params = AppLovinMAX.getInstance().getAdInfo( ad );
+            params.put( "adViewId", hashCode() );
+
             containerView.sendEvent( "OnAdViewAdClickedEvent", params );
         }
     }
@@ -174,6 +183,8 @@ class AppLovinMAXAdViewWidget
         if ( containerView != null )
         {
             Map<String, Object> params = AppLovinMAX.getInstance().getAdInfo( ad );
+            params.put( "adViewId", hashCode() );
+
             containerView.sendEvent( "OnAdViewAdExpandedEvent", params );
         }
     }
@@ -184,6 +195,8 @@ class AppLovinMAXAdViewWidget
         if ( containerView != null )
         {
             Map<String, Object> params = AppLovinMAX.getInstance().getAdInfo( ad );
+            params.put( "adViewId", hashCode() );
+
             containerView.sendEvent( "OnAdViewAdCollapsedEvent", params );
         }
     }
@@ -194,6 +207,8 @@ class AppLovinMAXAdViewWidget
         if ( containerView != null )
         {
             Map<String, Object> params = AppLovinMAX.getInstance().getAdInfo( ad );
+            params.put( "adViewId", hashCode() );
+
             containerView.sendEvent( "OnAdViewAdRevenuePaidEvent", params );
         }
     }

--- a/applovin_max/example/lib/main.dart
+++ b/applovin_max/example/lib/main.dart
@@ -233,9 +233,9 @@ class _MyAppState extends State<MyApp> {
   void preloadAdViewAd() {
     AppLovinMAX.setWidgetAdViewAdListener(WidgetAdViewAdListener(onAdLoadedCallback: (ad) {
       if (ad.adUnitId == _bannerAdUnitId) {
-        print('Banner ad preloaded (${ad.adViewId}) from ${ad.networkName}');
+        print('Banner ad (${ad.adViewId}) preloaded from ${ad.networkName}');
       } else if (ad.adUnitId == _mrecAdUnitId) {
-        print('MREC ad preloaded (${ad.adViewId}) from ${ad.networkName}');
+        print('MREC ad (${ad.adViewId}) preloaded from ${ad.networkName}');
       } else {
         print('Error: unexpected ad preloaded for ${ad.adUnitId}');
       }

--- a/applovin_max/example/lib/main.dart
+++ b/applovin_max/example/lib/main.dart
@@ -521,17 +521,17 @@ class _MyAppState extends State<MyApp> {
                       adFormat: AdFormat.banner,
                       adViewId: _preloadedBannerId,
                       listener: AdViewAdListener(onAdLoadedCallback: (ad) {
-                        logStatus('Banner widget ad loaded from ${ad.networkName}');
+                        logStatus('Banner widget ad (${ad.adViewId}) loaded from ${ad.networkName}');
                       }, onAdLoadFailedCallback: (adUnitId, error) {
-                        logStatus('Banner widget ad failed to load with error code ${error.code} and message: ${error.message}');
+                        logStatus('Banner widget ad (${error.adViewId}) failed to load with error code ${error.code} and message: ${error.message}');
                       }, onAdClickedCallback: (ad) {
-                        logStatus('Banner widget ad clicked');
+                        logStatus('Banner widget ad (${ad.adViewId}) clicked');
                       }, onAdExpandedCallback: (ad) {
-                        logStatus('Banner widget ad expanded');
+                        logStatus('Banner widget ad (${ad.adViewId}) expanded');
                       }, onAdCollapsedCallback: (ad) {
                         logStatus('Banner widget ad collapsed');
                       }, onAdRevenuePaidCallback: (ad) {
-                        logStatus('Banner widget ad revenue paid: ${ad.revenue}');
+                        logStatus('Banner widget ad (${ad.adViewId}) revenue paid: ${ad.revenue}');
                       })),
                 if (_isWidgetMRecShowing)
                   MaxAdView(
@@ -539,17 +539,17 @@ class _MyAppState extends State<MyApp> {
                       adFormat: AdFormat.mrec,
                       adViewId: _preloadedMRecId,
                       listener: AdViewAdListener(onAdLoadedCallback: (ad) {
-                        logStatus('MREC widget ad loaded from ${ad.networkName}');
+                        logStatus('MREC widget ad (${ad.adViewId}) loaded from ${ad.networkName}');
                       }, onAdLoadFailedCallback: (adUnitId, error) {
-                        logStatus('MREC widget ad failed to load with error code ${error.code} and message: ${error.message}');
+                        logStatus('MREC widget ad (${error.adViewId}) failed to load with error code ${error.code} and message: ${error.message}');
                       }, onAdClickedCallback: (ad) {
-                        logStatus('MREC widget ad clicked');
+                        logStatus('MREC widget ad (${ad.adViewId}) clicked');
                       }, onAdExpandedCallback: (ad) {
-                        logStatus('MREC widget ad expanded');
+                        logStatus('MREC widget ad (${ad.adViewId}) expanded');
                       }, onAdCollapsedCallback: (ad) {
-                        logStatus('MREC widget ad collapsed');
+                        logStatus('MREC widget ad (${ad.adViewId}) collapsed');
                       }, onAdRevenuePaidCallback: (ad) {
-                        logStatus('MREC widget ad revenue paid: ${ad.revenue}');
+                        logStatus('MREC widget ad (${ad.adViewId}) revenue paid: ${ad.revenue}');
                       })),
               ],
             ),

--- a/applovin_max/example/lib/main.dart
+++ b/applovin_max/example/lib/main.dart
@@ -50,6 +50,10 @@ var _isWidgetBannerShowing = false;
 var _isProgrammaticMRecCreated = false;
 var _isProgrammaticMRecShowing = false;
 var _isWidgetMRecShowing = false;
+var _preloadedBannerId;
+var _preloadedMRecId;
+var _preloadedBanner2Id;
+var _preloadedMRec2Id;
 
 var _statusText = '';
 
@@ -229,9 +233,9 @@ class _MyAppState extends State<MyApp> {
   void preloadAdViewAd() {
     AppLovinMAX.setWidgetAdViewAdListener(WidgetAdViewAdListener(onAdLoadedCallback: (ad) {
       if (ad.adUnitId == _bannerAdUnitId) {
-        print('Banner ad preloaded from ${ad.networkName}');
+        print('Banner ad preloaded (${ad.adViewId}) from ${ad.networkName}');
       } else if (ad.adUnitId == _mrecAdUnitId) {
-        print('MREC ad preloaded from ${ad.networkName}');
+        print('MREC ad preloaded (${ad.adViewId}) from ${ad.networkName}');
       } else {
         print('Error: unexpected ad preloaded for ${ad.adUnitId}');
       }
@@ -245,8 +249,9 @@ class _MyAppState extends State<MyApp> {
       }
     }));
 
-    AppLovinMAX.preloadWidgetAdView(_bannerAdUnitId, AdFormat.banner).then((_) {
-      print('Started preloading a banner ad for $_bannerAdUnitId');
+    AppLovinMAX.preloadWidgetAdView(_bannerAdUnitId, AdFormat.banner).then((adViewId) {
+      _preloadedBannerId = adViewId;
+      print('Started preloading a banner ad ($adViewId) for $_bannerAdUnitId');
     }).catchError((e) {
       print('Error: failed to preload a banner ad for $_bannerAdUnitId: $e');
     });
@@ -258,8 +263,23 @@ class _MyAppState extends State<MyApp> {
       customData: 'customData',
       extraParameters: {'key1': 'value1', 'key2': 'value2'},
       localExtraParameters: {'key1': 100, 'key2': 200},
-    ).then((_) {
-      print('Started preloading a MREC ad for $_mrecAdUnitId');
+    ).then((adViewId) {
+      _preloadedMRecId = adViewId;
+      print('Started preloading a MREC ad ($adViewId) for $_mrecAdUnitId');
+    }).catchError((e) {
+      print('Error: failed to preload a MREC ad for $_mrecAdUnitId: $e');
+    });
+
+    AppLovinMAX.preloadWidgetAdView(_bannerAdUnitId, AdFormat.banner).then((adViewId) {
+      _preloadedBanner2Id = adViewId;
+      print('Started preloading a banner ad ($adViewId) for $_bannerAdUnitId');
+    }).catchError((e) {
+      print('Error: failed to preload a banner ad for $_bannerAdUnitId: $e');
+    });
+
+    AppLovinMAX.preloadWidgetAdView(_mrecAdUnitId, AdFormat.mrec).then((adViewId) {
+      _preloadedMRec2Id = adViewId;
+      print('Started preloading a MREC ad ($adViewId) for $_mrecAdUnitId');
     }).catchError((e) {
       print('Error: failed to preload a MREC ad for $_mrecAdUnitId: $e');
     });
@@ -484,9 +504,12 @@ class _MyAppState extends State<MyApp> {
                             context,
                             MaterialPageRoute(
                                 builder: (context) => ScrolledAdView(
-                                      bannerAdUnitId: _bannerAdUnitId,
-                                      mrecAdUnitId: _mrecAdUnitId,
-                                    )),
+                                    bannerAdUnitId: _bannerAdUnitId,
+                                    mrecAdUnitId: _mrecAdUnitId,
+                                    preloadedBannerId: _preloadedBannerId,
+                                    preloadedMRecId: _preloadedMRecId,
+                                    preloadedBanner2Id: _preloadedBanner2Id,
+                                    preloadedMRec2Id: _preloadedMRec2Id)),
                           );
                         }
                       : null,
@@ -496,6 +519,7 @@ class _MyAppState extends State<MyApp> {
                   MaxAdView(
                       adUnitId: _bannerAdUnitId,
                       adFormat: AdFormat.banner,
+                      adViewId: _preloadedBannerId,
                       listener: AdViewAdListener(onAdLoadedCallback: (ad) {
                         logStatus('Banner widget ad loaded from ${ad.networkName}');
                       }, onAdLoadFailedCallback: (adUnitId, error) {
@@ -513,6 +537,7 @@ class _MyAppState extends State<MyApp> {
                   MaxAdView(
                       adUnitId: _mrecAdUnitId,
                       adFormat: AdFormat.mrec,
+                      adViewId: _preloadedMRecId,
                       listener: AdViewAdListener(onAdLoadedCallback: (ad) {
                         logStatus('MREC widget ad loaded from ${ad.networkName}');
                       }, onAdLoadFailedCallback: (adUnitId, error) {

--- a/applovin_max/example/lib/scrolled_adview.dart
+++ b/applovin_max/example/lib/scrolled_adview.dart
@@ -7,10 +7,18 @@ class ScrolledAdView extends StatefulWidget {
     super.key,
     required this.bannerAdUnitId,
     required this.mrecAdUnitId,
+    this.preloadedBannerId,
+    this.preloadedMRecId,
+    this.preloadedBanner2Id,
+    this.preloadedMRec2Id,
   });
 
   final String bannerAdUnitId;
   final String mrecAdUnitId;
+  final AdViewId? preloadedBannerId;
+  final AdViewId? preloadedMRecId;
+  final AdViewId? preloadedBanner2Id;
+  final AdViewId? preloadedMRec2Id;
 
   @override
   State createState() => ScrolledAdViewState();
@@ -47,33 +55,80 @@ class ScrolledAdViewState extends State<ScrolledAdView> {
                     text: _isAdEnabled ? 'Disable ADs' : 'Enable ADs',
                   ),
                   Expanded(
-                    child: ListView.builder(
-                      padding: const EdgeInsets.all(4),
-                      shrinkWrap: true,
-                      itemCount: 4,
-                      itemBuilder: (BuildContext context, int index) {
-                        return Column(children: [
-                          const Text(
-                            _sampleText,
-                            textAlign: TextAlign.justify,
-                            style: TextStyle(fontSize: 18.0),
-                          ),
-                          _isAdEnabled
-                              ? (index % 2 == 0)
-                                  ? MaxAdView(adUnitId: widget.bannerAdUnitId, adFormat: AdFormat.banner)
-                                  : MaxAdView(adUnitId: widget.mrecAdUnitId, adFormat: AdFormat.mrec)
-                              : const SizedBox(
-                                  height: 50,
-                                  child: Center(child: Text('AD Placeholder')),
-                                ),
-                          const Text(
-                            _sampleText,
-                            textAlign: TextAlign.justify,
-                            style: TextStyle(fontSize: 18.0),
-                          ),
-                        ]);
-                      },
-                    ),
+                    child: ListView(padding: const EdgeInsets.all(4), shrinkWrap: true, children: [
+                      Column(children: [
+                        const Text(
+                          _sampleText,
+                          textAlign: TextAlign.justify,
+                          style: TextStyle(fontSize: 18.0),
+                        ),
+                        _isAdEnabled
+                            ? MaxAdView(adUnitId: widget.bannerAdUnitId, adFormat: AdFormat.banner, adViewId: widget.preloadedBannerId)
+                            : const SizedBox(
+                                height: 50,
+                                child: Center(child: Text('AD Placeholder')),
+                              ),
+                        const Text(
+                          _sampleText,
+                          textAlign: TextAlign.justify,
+                          style: TextStyle(fontSize: 18.0),
+                        ),
+                      ]),
+                      Column(children: [
+                        const Text(
+                          _sampleText,
+                          textAlign: TextAlign.justify,
+                          style: TextStyle(fontSize: 18.0),
+                        ),
+                        _isAdEnabled
+                            ? MaxAdView(adUnitId: widget.mrecAdUnitId, adFormat: AdFormat.mrec, adViewId: widget.preloadedMRecId)
+                            : const SizedBox(
+                                height: 50,
+                                child: Center(child: Text('AD Placeholder')),
+                              ),
+                        const Text(
+                          _sampleText,
+                          textAlign: TextAlign.justify,
+                          style: TextStyle(fontSize: 18.0),
+                        ),
+                      ]),
+                      Column(children: [
+                        const Text(
+                          _sampleText,
+                          textAlign: TextAlign.justify,
+                          style: TextStyle(fontSize: 18.0),
+                        ),
+                        _isAdEnabled
+                            ? MaxAdView(adUnitId: widget.bannerAdUnitId, adFormat: AdFormat.banner, adViewId: widget.preloadedBanner2Id)
+                            : const SizedBox(
+                                height: 50,
+                                child: Center(child: Text('AD Placeholder')),
+                              ),
+                        const Text(
+                          _sampleText,
+                          textAlign: TextAlign.justify,
+                          style: TextStyle(fontSize: 18.0),
+                        ),
+                      ]),
+                      Column(children: [
+                        const Text(
+                          _sampleText,
+                          textAlign: TextAlign.justify,
+                          style: TextStyle(fontSize: 18.0),
+                        ),
+                        _isAdEnabled
+                            ? MaxAdView(adUnitId: widget.mrecAdUnitId, adFormat: AdFormat.mrec, adViewId: widget.preloadedMRec2Id)
+                            : const SizedBox(
+                                height: 50,
+                                child: Center(child: Text('AD Placeholder')),
+                              ),
+                        const Text(
+                          _sampleText,
+                          textAlign: TextAlign.justify,
+                          style: TextStyle(fontSize: 18.0),
+                        ),
+                      ])
+                    ]),
                   ),
                   _isAdEnabled
                       ? MaxAdView(adUnitId: widget.bannerAdUnitId, adFormat: AdFormat.banner)

--- a/applovin_max/ios/Classes/AppLovinMAX.m
+++ b/applovin_max/ios/Classes/AppLovinMAX.m
@@ -78,7 +78,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
         @"4.0.1" : @"13.0.0",
         @"4.0.0" : @"13.0.0"
     };
-
+    
     ALSharedChannel = [FlutterMethodChannel methodChannelWithName: @"applovin_max" binaryMessenger: [registrar messenger]];
     AppLovinMAX *instance = [[AppLovinMAX alloc] init];
     [registrar addMethodCallDelegate: instance channel: ALSharedChannel];
@@ -114,14 +114,14 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
         self.adViewConstraints = [NSMutableDictionary dictionaryWithCapacity: 2];
         self.adUnitIdentifiersToShowAfterCreate = [NSMutableArray arrayWithCapacity: 2];
         self.disabledAutoRefreshAdViewAdUnitIdentifiers = [NSMutableSet setWithCapacity: 2];
-
+        
         self.safeAreaBackground = [[UIView alloc] init];
         self.safeAreaBackground.hidden = YES;
         self.safeAreaBackground.backgroundColor = UIColor.clearColor;
         self.safeAreaBackground.translatesAutoresizingMaskIntoConstraints = NO;
         self.safeAreaBackground.userInteractionEnabled = NO;
         [ROOT_VIEW_CONTROLLER.view addSubview: self.safeAreaBackground];
-
+        
         // Check that plugin version is compatible with native SDK version
         NSString *minCompatibleNativeSdkVersion = ALCompatibleNativeSDKVersions[PLUGIN_VERSION];
         BOOL isCompatible = [ALUtils isInclusiveVersion: ALSdk.version
@@ -174,7 +174,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
     }
     
     ALSdkInitializationConfiguration *initConfig = [ALSdkInitializationConfiguration configurationWithSdkKey: sdkKey builderBlock:^(ALSdkInitializationConfigurationBuilder *builder) {
-
+        
         builder.mediationProvider = ALMediationProviderMAX;
         builder.pluginVersion = [@"Flutter-" stringByAppendingString: pluginVersion];
         builder.segmentCollection = [self.segmentCollectionBuilder build];
@@ -189,11 +189,11 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
             self.testDeviceIdentifiersToSet = nil;
         }
     }];
-
-
+    
+    
     // Initialize SDK
     [self.sdk initializeWithConfiguration:initConfig completionHandler:^(ALSdkConfiguration *configuration) {
-
+        
         [self log: @"SDK initialized"];
         
         self.sdkConfiguration = configuration;
@@ -295,7 +295,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
         [self log: @"[%@] Failed to set extra parameter for nil or empty key: %@", TAG, key];
         return;
     }
-
+    
     [self.sdk.settings setExtraParameterForKey: key value: ( value != (id) [NSNull null] ) ? value : nil];
 }
 
@@ -333,7 +333,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
         [self logUninitializedAccessError: @"showCmpForExistingUser" withResult: result];
         return;
     }
-
+    
     [self.sdk.cmpService showCMPForExistingUserWithCompletion:^(ALCMPError * _Nullable error) {
         
         if ( !error )
@@ -341,7 +341,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
             result(nil);
             return;
         }
-
+        
         result(@{@"code" : @(error.code),
                  @"message" : error.message ?: @"",
                  @"cmpCode" : @(error.cmpCode),
@@ -356,7 +356,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
         [self logUninitializedAccessError: @"hasSupportedCmp" withResult: result];
         return;
     }
-
+    
     result(@([self.sdk.cmpService hasSupportedCMP]));
 }
 
@@ -382,7 +382,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
     }
     
     NSArray<MASegment *> *segments = self.sdk.segmentCollection.segments;
-
+    
     if ( ![segments count] )
     {
         result(nil);
@@ -395,7 +395,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
     {
         map[segment.key] = segment.values;
     }
-
+    
     result(map);
 }
 
@@ -1074,13 +1074,13 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
 - (void)logUninitializedAccessError:(NSString *)callingMethod withResult:(nullable FlutterResult)result
 {
     NSString *message = [NSString stringWithFormat: @"ERROR: Failed to execute %@() - please ensure the AppLovin MAX React Native module has been initialized by calling 'AppLovinMAX.initialize(...);'!", callingMethod];
-
+    
     if ( !result )
     {
         NSLog(@"[%@] [%@] %@", SDK_TAG, TAG, message);
         return;
     }
-
+    
     result([FlutterError errorWithCode: TAG message: message details: nil]);
 }
 
@@ -1463,7 +1463,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
             [self log: @"Failed to set Amazon result - unable to find interstitial"];
             return;
         }
-
+        
         [interstitial setLocalExtraParameterForKey: key value: result];
     }
     else if ( adFormat == MAAdFormat.rewarded )
@@ -1474,13 +1474,13 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
             [self log: @"Failed to set Amazon result - unable to find rewarded ad"];
             return;
         }
-
+        
         [rewardedAd setLocalExtraParameterForKey: key value: result];
     }
     else // MAAdFormat.banner or MAAdFormat.mrec
     {
         MAAdView *adView = [AppLovinMAXAdView sharedWithAdUnitIdentifier: adUnitIdentifier];
-
+        
         if ( !adView )
         {
             adView = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat];
@@ -1515,7 +1515,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
     {
         return ALConsentFlowUserGeographyOther;
     }
-
+    
     return ALConsentFlowUserGeographyUnknown;
 }
 
@@ -1529,7 +1529,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
     {
         return USER_GEOGRAPHY_OTHER;
     }
-
+    
     return USER_GEOGRAPHY_UNKNOWN;
 }
 
@@ -1551,7 +1551,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
     {
         return APP_TRACKING_STATUS_AUTHORIZED;
     }
-
+    
     return APP_TRACKING_STATUS_UNAVAILABLE;
 }
 
@@ -1976,14 +1976,14 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
         id rawCustomData = call.arguments[@"custom_data"];
         id rawExtraParameters = call.arguments[@"extra_parameters"];
         id rawLocalExtraParameters = call.arguments[@"local_extra_parameters"];
-
+        
         NSString *placement = ( rawPlacement != [NSNull null] ) ? rawPlacement : nil;
         NSString *customData = ( rawCustomData != [NSNull null] ) ? rawCustomData : nil;
         NSDictionary<NSString *, id> *extraParameters = ( rawExtraParameters != [NSNull null] ) ? rawExtraParameters : nil;
         NSDictionary<NSString *, id> *localExtraParameters = ( rawLocalExtraParameters != [NSNull null] ) ? rawLocalExtraParameters : nil;
-
+        
         MAAdFormat *adFormat;
-    
+        
         if ( [MAAdFormat.banner.label al_isEqualToStringIgnoringCase: adFormatStr] )
         {
             adFormat = DEVICE_SPECIFIC_ADVIEW_AD_FORMAT;
@@ -1997,7 +1997,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
             [self logInvalidAdFormat: adFormat withResult: result];
             return;
         }
-    
+        
         [AppLovinMAXAdView preloadWidgetAdView: adUnitId
                                       adFormat: adFormat
                                      placement: placement
@@ -2008,16 +2008,16 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
     }
     else if ( [@"destroyWidgetAdView" isEqualToString: call.method] )
     {
-        NSString *adUnitId = call.arguments[@"ad_unit_id"];
-        [AppLovinMAXAdView destroyWidgetAdView: adUnitId withResult: result];
+        NSNumber *adViewId = call.arguments[@"ad_view_id"];
+        [AppLovinMAXAdView destroyWidgetAdView: adViewId withResult: result];
     }
     else if ( [@"addSegment" isEqualToString: call.method] )
     {
         NSNumber *key = call.arguments[@"key"];
         NSArray<NSNumber *> *values = call.arguments[@"values"];
-
+        
         [self addSegment: key values: values];
-
+        
         result(nil);
     }
     else if ( [@"getSegments" isEqualToString: call.method] )

--- a/applovin_max/ios/Classes/AppLovinMAXAdView.h
+++ b/applovin_max/ios/Classes/AppLovinMAXAdView.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AppLovinMAXAdView : NSObject<FlutterPlatformView>
 
-+ (MAAdView *)sharedWithAdUnitIdentifier:(NSString *)adUnitIdentifier;
++ (nullable MAAdView *)sharedWithAdUnitIdentifier:(NSString *)adUnitIdentifier;
 
 + (void)preloadWidgetAdView:(NSString *)adUnitIdentifier 
                    adFormat:(MAAdFormat *)adFormat
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
        localExtraParameters:(nullable NSDictionary<NSString *, id> *)localExtraParameters
                  withResult:(FlutterResult)result;
 
-+ (void)destroyWidgetAdView:(NSString *)adUnitIdentifier withResult:(FlutterResult)result;
++ (void)destroyWidgetAdView:(NSNumber *)adViewId withResult:(FlutterResult)result;
 
 - (void)sendEventWithName:(NSString *)name body:(NSDictionary<NSString *, id> *)body;
 
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
                        viewId:(int64_t)viewId
                      adUnitId:(NSString *)adUnitId
                      adFormat:(MAAdFormat *)adFormat
+                     adViewId:(nullable NSNumber *)adViewId
          isAutoRefreshEnabled:(BOOL)isAutoRefreshEnabled
                     placement:(nullable NSString *)placement
                    customData:(nullable NSString *)customData

--- a/applovin_max/ios/Classes/AppLovinMAXAdViewFactory.m
+++ b/applovin_max/ios/Classes/AppLovinMAXAdViewFactory.m
@@ -45,9 +45,8 @@
     NSString *adFormatStr = args[@"ad_format"];
     MAAdFormat *adFormat = [adFormatStr isEqualToString: @"mrec"] ? MAAdFormat.mrec : DEVICE_SPECIFIC_ADVIEW_AD_FORMAT;
     
-    [AppLovinMAX log: @"Creating MaxAdView widget with Ad Unit ID: %@", adUnitId];
-    
     // Optional params
+    NSNumber *adViewId = [args[@"ad_view_id"] isKindOfClass: [NSNumber class]] ? args[@"ad_view_id"] : nil; // May be NSNull
     BOOL isAutoRefreshEnabled = ((NSNumber *) args[@"is_auto_refresh_enabled"]).boolValue; // Defaults to true
     NSString *placement = [args[@"placement"] isKindOfClass: [NSString class]] ? args[@"placement"] : nil; // May be NSNull
     NSString *customData = [args[@"custom_data"] isKindOfClass: [NSString class]] ? args[@"custom_data"] : nil; // May be NSNull
@@ -58,6 +57,7 @@
                                              viewId: viewId
                                            adUnitId: adUnitId
                                            adFormat: adFormat
+                                           adViewId: adViewId
                                isAutoRefreshEnabled: isAutoRefreshEnabled
                                           placement: placement
                                          customData: customData

--- a/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.h
+++ b/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.h
@@ -5,6 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AppLovinMAXAdViewWidget : NSObject
 
 @property (nonatomic, strong, readonly) MAAdView *adView;
+@property (nonatomic, copy,   readonly) NSString *adUnitIdentifier;
 @property (nonatomic, assign, readonly) BOOL hasContainerView;
 
 @property (nonatomic, copy, nullable) NSString *placement;

--- a/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
+++ b/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
@@ -24,7 +24,7 @@
     if ( self )
     {
         self.shouldPreload = shouldPreload;
-
+        
         self.adView = [[MAAdView alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat sdk: [AppLovinMAX shared].sdk];
         self.adView.delegate = self;
         self.adView.revenueDelegate = self;
@@ -33,11 +33,16 @@
         [self.adView setExtraParameterForKey: @"allow_pause_auto_refresh_immediately" value: @"true"];
         
         [self.adView stopAutoRefresh];
-
+        
         // Set a frame size to suppress an error of zero area for MAAdView
         self.adView.frame = (CGRect) { CGPointZero, adFormat.size };
     }
     return self;
+}
+
+- (NSString *)adUnitIdentifier
+{
+    return self.adView.adUnitIdentifier;
 }
 
 - (void)setPlacement:(NSString *)placement
@@ -113,7 +118,8 @@
 
 - (void)didLoadAd:(MAAd *)ad
 {
-    NSDictionary *adInfo = [[AppLovinMAX shared] adInfoForAd: ad];
+    NSMutableDictionary *adInfo = [@{@"adViewId": @(self.hash)} mutableCopy];
+    [adInfo addEntriesFromDictionary: [[AppLovinMAX shared] adInfoForAd: ad]];
     
     if ( self.shouldPreload )
     {
@@ -128,7 +134,8 @@
 
 - (void)didFailToLoadAdForAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(MAError *)error
 {
-    NSDictionary *adLoadFailedInfo = [[AppLovinMAX shared] adLoadFailedInfoForAdUnitIdentifier: adUnitIdentifier withError: error];
+    NSMutableDictionary *adLoadFailedInfo = [@{@"adViewId": @(self.hash)} mutableCopy];
+    [adLoadFailedInfo addEntriesFromDictionary: [[AppLovinMAX shared] adLoadFailedInfoForAdUnitIdentifier: adUnitIdentifier withError: error]];
     
     if ( self.shouldPreload )
     {
@@ -145,7 +152,9 @@
 {
     if ( self.containerView )
     {
-        NSDictionary *adInfo = [[AppLovinMAX shared] adInfoForAd: ad];
+        NSMutableDictionary *adInfo = [@{@"adViewId": @(self.hash)} mutableCopy];
+        [adInfo addEntriesFromDictionary: [[AppLovinMAX shared] adInfoForAd: ad]];
+        
         [self.containerView sendEventWithName: @"OnAdViewAdClickedEvent" body: adInfo];
     }
 }
@@ -156,7 +165,9 @@
 {
     if ( self.containerView )
     {
-        NSDictionary *adInfo = [[AppLovinMAX shared] adInfoForAd: ad];
+        NSMutableDictionary *adInfo = [@{@"adViewId": @(self.hash)} mutableCopy];
+        [adInfo addEntriesFromDictionary: [[AppLovinMAX shared] adInfoForAd: ad]];
+        
         [self.containerView sendEventWithName: @"OnAdViewAdExpandedEvent" body: adInfo];
     }
 }
@@ -165,7 +176,9 @@
 {
     if ( self.containerView )
     {
-        NSDictionary *adInfo = [[AppLovinMAX shared] adInfoForAd: ad];
+        NSMutableDictionary *adInfo = [@{@"adViewId": @(self.hash)} mutableCopy];
+        [adInfo addEntriesFromDictionary: [[AppLovinMAX shared] adInfoForAd: ad]];
+        
         [self.containerView sendEventWithName: @"OnAdViewAdCollapsedEvent" body: adInfo];
     }
 }
@@ -176,7 +189,9 @@
 {
     if ( self.containerView )
     {
-        NSDictionary *adInfo = [[AppLovinMAX shared] adInfoForAd: ad];
+        NSMutableDictionary *adInfo = [@{@"adViewId": @(self.hash)} mutableCopy];
+        [adInfo addEntriesFromDictionary: [[AppLovinMAX shared] adInfoForAd: ad]];
+        
         [self.containerView sendEventWithName: @"OnAdViewAdRevenuePaidEvent" body: adInfo];
     }
 }

--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -695,26 +695,23 @@ class AppLovinMAX {
     _widgetAdViewAdListener = listener;
   }
 
-  /// Preloads a [MaxAdView] platform widget for the specified [adUnitId] with
-  /// the given [adFormat] before it is mounted in the widget tree.
+  /// Preloads a [MaxAdView] platform widget for the specified [adUnitId] and [adFormat].
   ///
-  /// When you mount a [MaxAdView] with the preloaded [adUnitId], it will be
-  /// constructed using the preloaded [MaxAdView] platform widget, allowing ads
-  /// to be displayed more quickly. After unmounting the [MaxAdView], the
-  /// preloaded [MaxAdView] platform widget will not be destroyed; instead, it
-  /// will be reused for the next mount. You must manually destroy it when it is
-  /// no longer needed.
+  /// Preloading a [MaxAdView] improves ad rendering speed when the widget is later
+  /// mounted in the widget tree. The preloaded platform widget is reused across
+  /// mounts for the same [adViewId] until explicitly destroyed, reducing load times.
   ///
-  /// You can preload only one [MaxAdView] platform widget for a single Ad Unit
-  /// ID. If you mount two [MaxAdView] widgets with the same Ad Unit ID, the
-  /// first [MaxAdView] will use the preloaded platform widget, while the second
-  /// [MaxAdView] will create its own platform widget and destroy it upon
-  /// unmounting.
+  /// - **Behavior**:
+  ///   - When a [MaxAdView] is mounted with the preloaded [adViewId], it uses the
+  ///     preloaded platform widget for faster rendering.
   ///
-  /// Returns a `Future<void>` that completes when the preload operation has
-  /// been successfully started. If the preload operation fails to start, the
-  /// `Future` completes with an error.
-  static Future<void> preloadWidgetAdView(
+  /// - **Important**: Preloaded platform widgets must be destroyed manually using
+  ///   [destroyWidgetAdView] when they are no longer needed to free up resources.
+  ///
+  /// - **Return**:
+  ///   A `Future<AdViewId?>` that completes when the preload operation starts
+  ///   successfully. If the operation fails, the `Future` completes with an error.
+  static Future<AdViewId?> preloadWidgetAdView(
     String adUnitId,
     AdFormat adFormat, {
     String? placement,
@@ -732,14 +729,17 @@ class AppLovinMAX {
     });
   }
 
-  /// Destroys a [MaxAdView] platform widget for the specified [adUnitId].
+  /// Destroys the preloaded [MaxAdView] platform widget associated with the specified [adViewId].
   ///
-  /// Returns a `Future<void>` that completes the destruction of the [MaxAdView]
-  /// platform widget. If the destruction operation fails, the `Future`
-  /// completes with an error.
-  static Future<void> destroyWidgetAdView(String adUnitId) {
+  /// This method releases resources associated with the preloaded platform widget,
+  /// ensuring that no unnecessary memory or platform-side resources remain allocated.
+  ///
+  /// - **Return**:
+  ///   A `Future<void>` that completes once the destruction operation is successful.
+  ///   If the operation fails, the `Future` completes with an error.
+  static Future<void> destroyWidgetAdView(AdViewId adViewId) {
     return _methodChannel.invokeMethod('destroyWidgetAdView', {
-      'ad_unit_id': adUnitId,
+      'ad_view_id': adViewId,
     });
   }
 

--- a/applovin_max/lib/src/ad_classes.dart
+++ b/applovin_max/lib/src/ad_classes.dart
@@ -1,9 +1,15 @@
 import 'package:applovin_max/src/enums.dart';
 
+/// A unique identifier used to reference a specific platform widget AdView instance.
+typedef AdViewId = num;
+
 /// Represents an ad that has been served by AppLovin MAX.
 class MaxAd {
   /// The ad unit ID for which this ad was loaded.
   final String adUnitId;
+
+  /// The unique ID of the platform widget AdView.
+  final AdViewId? adViewId;
 
   /// The ad network from which this ad was loaded.
   final String networkName;
@@ -39,7 +45,8 @@ class MaxAd {
   final MaxNativeAd? nativeAd;
 
   /// @nodoc
-  MaxAd(this.adUnitId, this.networkName, this.revenue, this.revenuePrecision, this.creativeId, this.dspName, this.placement, this.waterfall, this.nativeAd);
+  MaxAd(this.adUnitId, this.adViewId, this.networkName, this.revenue, this.revenuePrecision, this.creativeId, this.dspName, this.placement, this.waterfall,
+      this.nativeAd);
 
   /// @nodoc
   factory MaxAd.fromJson(Map<String, dynamic> json) {
@@ -50,6 +57,7 @@ class MaxAd {
 
     return MaxAd(
       json['adUnitId'] as String,
+      json['adViewId'] as AdViewId?,
       json['networkName'] as String,
       double.tryParse(json['revenue']?.toString() ?? '0.0') ?? 0.0,
       json['revenuePrecision'] as String,
@@ -64,6 +72,7 @@ class MaxAd {
   @override
   String toString() {
     return '{MaxAd: {adUnitId: $adUnitId'
+        ', adViewId: $adViewId'
         ', networkName: $networkName'
         ', revenue: $revenue'
         ', revenuePrecision: $revenuePrecision'
@@ -159,15 +168,20 @@ class MaxError {
   /// The error message for the error.
   final String message;
 
+  /// The unique ID of the platform widget AdView.
+  final AdViewId? adViewId;
+
   /// The underlying waterfall of ad responses.
   final MaxAdWaterfallInfo? waterfall;
 
   /// @nodoc
-  MaxError(this.code, this.message, this.waterfall);
+  MaxError(this.code, this.message, this.adViewId, this.waterfall);
 
   /// @nodoc
   factory MaxError.fromJson(Map<String, dynamic> json) {
     ErrorCode code = ErrorCode.fromValue(json['code'] as int);
+
+    AdViewId? adViewId = json['adViewId'] as AdViewId?;
 
     MaxAdWaterfallInfo? waterfall;
     if (json['waterfall'] != null) {
@@ -177,7 +191,7 @@ class MaxError {
       }
     }
 
-    return MaxError(code, json['message'] as String, waterfall);
+    return MaxError(code, json['message'] as String, adViewId, waterfall);
   }
 
   @override

--- a/applovin_max/lib/src/max_ad_view.dart
+++ b/applovin_max/lib/src/max_ad_view.dart
@@ -23,6 +23,10 @@ class MaxAdView extends StatefulWidget {
   /// either [AdFormat.banner] or [AdFormat.mrec].
   final AdFormat adFormat;
 
+  /// A unique identifier representing the platform widget AdView instance.
+  /// Used to manage and track the specific platform widget AdView.
+  final AdViewId? adViewId;
+
   /// A string value representing the placement name that you assign when you
   /// integrate each ad format, for granular reporting in ad events.
   final String? placement;
@@ -51,6 +55,7 @@ class MaxAdView extends StatefulWidget {
     Key? key,
     required this.adUnitId,
     required this.adFormat,
+    this.adViewId,
     this.placement,
     this.customData,
     this.extraParameters,
@@ -114,6 +119,7 @@ class _MaxAdViewState extends State<MaxAdView> {
     return {
       "ad_unit_id": widget.adUnitId,
       "ad_format": widget.adFormat.value,
+      "ad_view_id": widget.adViewId,
       "is_auto_refresh_enabled": widget.isAutoRefreshEnabled,
       "custom_data": widget.customData,
       "placement": widget.placement,


### PR DESCRIPTION
Enhance banner and MREC preloading to support preloading multiple AdView instances.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance banner and MREC (`MaxAdView`) preloading to support preloading multiple `MaxAdView` instances by using a unique `adViewId` identifier instead of the previous single ad unit ID approach.

### Why are these changes being made?

These changes are being made to improve the flexibility and efficiency of the ad preloading process, allowing multiple ad views to be preloaded and managed independently. Switching from an `ad_unit_id` to a unique `adViewId` enables more granular control over ad instances, ensuring better resource management and avoiding conflicts where multiple `MaxAdView` instances need to be managed simultaneously. This enhancement is particularly useful in dynamic applications where multiple ads may need to be preloaded and displayed in a seamless manner.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->