### PR TITLE
fix/remove_adaptive_banner_from_android

### DIFF
--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdViewWidget.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdViewWidget.java
@@ -38,8 +38,6 @@ class AppLovinMAXAdViewWidget
         adView.setListener( this );
         adView.setRevenueListener( this );
 
-        adView.setExtraParameter( "adaptive_banner", "true" );
-
         // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
         adView.setExtraParameter( "allow_pause_auto_refresh_immediately", "true" );
 


### PR DESCRIPTION
Remove `adaptive_banner` from Android.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Remove the setting of the extra parameter "adaptive_banner" from the Android `AppLovinMAXAdViewWidget` class.

### Why are these changes being made?
The adaptive banner configuration is no longer required and its removal simplifies the code by eliminating redundant settings, ensuring the widget aligns with the current SDK needs and best practices. This change also helps avoid potential conflicts or issues arising from using deprecated or unsupported parameters.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->