### PR TITLE
ref/remove_obsolete_error_codes

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Remove obsolete MAX Error Codes - `fullscreenAdAlreadyLoading` and `fullscreenAdLoadWhileShowing`.
+* Remove obsolete MAX Error Codes - `ErrorCode.fullscreenAdAlreadyLoading` and `ErrorCode.fullscreenAdLoadWhileShowing`.
 ## 4.1.0
 * Enhance banner and MREC (`MaxAdView`) preloading to support preloading multiple `MaxAdView` instances.
 * Update preloaded banners and MRECs (`MaxAdView`) to suspend auto-refresh while not visible in background.

--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Remove obsolete MAX Error Codes - `fullscreenAdAlreadyLoading` and `fullscreenAdLoadWhileShowing`.
 ## 4.1.0
 * Enhance banner and MREC (`MaxAdView`) preloading to support preloading multiple `MaxAdView` instances.
 * Update preloaded banners and MRECs (`MaxAdView`) to suspend auto-refresh while not visible in background.

--- a/applovin_max/example/lib/main.dart
+++ b/applovin_max/example/lib/main.dart
@@ -102,14 +102,6 @@ class _MyAppState extends State<MyApp> {
       onAdLoadFailedCallback: (adUnitId, error) {
         _interstitialLoadState = AdLoadState.notLoaded;
 
-        if (error.code == ErrorCode.fullscreenAdAlreadyLoading) {
-          logStatus('Interstitial ad failed: ad is already loading');
-          return;
-        } else if (error.code == ErrorCode.fullscreenAdLoadWhileShowing) {
-          logStatus('Interstitial ad failed: ad is currently being shown for this ad unit');
-          return;
-        }
-
         // Interstitial ad failed to load
         // We recommend retrying with exponentially higher delays up to a maximum delay (in this case 64 seconds)
         _interstitialRetryAttempt = _interstitialRetryAttempt + 1;
@@ -157,14 +149,6 @@ class _MyAppState extends State<MyApp> {
       _rewardedAdRetryAttempt = 0;
     }, onAdLoadFailedCallback: (adUnitId, error) {
       _rewardedAdLoadState = AdLoadState.notLoaded;
-
-      if (error.code == ErrorCode.fullscreenAdAlreadyLoading) {
-        logStatus('Rewarded ad failed: ad is already loading');
-        return;
-      } else if (error.code == ErrorCode.fullscreenAdLoadWhileShowing) {
-        logStatus('Rewarded ad failed: ad is currently being shown for this ad unit');
-        return;
-      }
 
       // Rewarded ad failed to load
       // We recommend retrying with exponentially higher delays up to a maximum delay (in this case 64 seconds)

--- a/applovin_max/lib/src/enums.dart
+++ b/applovin_max/lib/src/enums.dart
@@ -190,14 +190,6 @@ enum ErrorCode {
   /// Note: iOS only.
   fullscreenAdInvalidViewController(-25),
 
-  /// This error code indicates you are attempting to load a fullscreen ad while another
-  /// fullscreen ad is already loading.
-  fullscreenAdAlreadyLoading(-26),
-
-  /// This error code indicates you are attempting to load a fullscreen ad while another fullscreen ad
-  /// is still showing.
-  fullscreenAdLoadWhileShowing(-27),
-
   /// This error code indicates that the SDK failed to display an ad because the
   /// user has the "Don't Keep Activities" developer setting enabled.
   ///


### PR DESCRIPTION
Remove fullscreenAdAlreadyLoading and fullscreenAdLoadWhileShowing.   Will merge before release_4_1_1.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove obsolete MAX Error Codes `fullscreenAdAlreadyLoading` and `fullscreenAdLoadWhileShowing` from the project.

### Why are these changes being made?

These error codes have been identified as obsolete and no longer applicable for current ad handling processes within the AppLovin MAX SDK. Removing them helps clean up the codebase and avoid confusion about error state representations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->