### PR TITLE
fix/preloaded_adview_not_resuming_auto_refresh_on_ios

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix preloaded AdView not resuming auto-refresh on iOS.
 ## 4.1.1
 * Remove the mistakenly enabled adaptive banner from Android to prevent app-side errors.
 * Remove obsolete MAX Error Codes - `ErrorCode.fullscreenAdAlreadyLoading` and `ErrorCode.fullscreenAdLoadWhileShowing`.

--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Fix preloaded AdView not resuming auto-refresh on iOS.
+* Fix preloaded banners and MRECs not resuming auto-refresh on iOS.
 ## 4.1.1
 * Remove the mistakenly enabled adaptive banner from Android to prevent app-side errors.
 * Remove obsolete MAX Error Codes - `ErrorCode.fullscreenAdAlreadyLoading` and `ErrorCode.fullscreenAdLoadWhileShowing`.

--- a/applovin_max/ios/Classes/AppLovinMAXAdView.m
+++ b/applovin_max/ios/Classes/AppLovinMAXAdView.m
@@ -67,10 +67,10 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewWidget *> *preloadedWidg
     AppLovinMAXAdViewWidget *preloadedWidget = [[AppLovinMAXAdViewWidget alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat shouldPreload: YES];
     preloadedWidgetInstances[@(preloadedWidget.hash)] = preloadedWidget;
     
-    preloadedWidget.placement = placement;
-    preloadedWidget.customData = customData;
-    preloadedWidget.extraParameters = extraParameters;
-    preloadedWidget.localExtraParameters = localExtraParameters;
+    [preloadedWidget setPlacement: placement];
+    [preloadedWidget setCustomData: customData];
+    [preloadedWidget setExtraParameters: extraParameters];
+    [preloadedWidget setLocalExtraParameters: localExtraParameters];
     
     [preloadedWidget loadAd];
     
@@ -150,7 +150,7 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewWidget *> *preloadedWidg
                 [AppLovinMAX log: @"Mounting the preloaded AdView (%@) for Ad Unit ID %@", adViewId, adUnitId];
                 
                 self.adViewId = adViewId;
-                self.widget.autoRefreshEnabled = isAutoRefreshEnabled;
+                [self.widget setAutoRefreshEnabled: isAutoRefreshEnabled];
                 [self.widget attachAdView: self];
                 return self;
             }
@@ -162,11 +162,11 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewWidget *> *preloadedWidg
         
         [AppLovinMAX log: @"Mounting a new AdView (%@) for Ad Unit ID %@", self.adViewId, adUnitId];
         
-        self.widget.placement = placement;
-        self.widget.customData = customData;
-        self.widget.extraParameters = extraParameters;
-        self.widget.localExtraParameters = localExtraParameters;
-        self.widget.autoRefreshEnabled = isAutoRefreshEnabled;
+        [self.widget setPlacement: placement];
+        [self.widget setCustomData: customData];
+        [self.widget setExtraParameters: extraParameters];
+        [self.widget setLocalExtraParameters: localExtraParameters];
+        [self.widget setAutoRefreshEnabled: isAutoRefreshEnabled];
         
         [self.widget attachAdView: self];
         [self.widget loadAd];
@@ -189,7 +189,7 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewWidget *> *preloadedWidg
     {
         [AppLovinMAX log: @"Unmounting the preloaded AdView (%@) for Ad Unit ID %@", self.adViewId, self.widget.adUnitIdentifier];
         
-        self.widget.autoRefreshEnabled = NO;
+        [self.widget setAutoRefreshEnabled: NO];
     }
     else
     {

--- a/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.h
+++ b/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.h
@@ -8,11 +8,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy,   readonly) NSString *adUnitIdentifier;
 @property (nonatomic, assign, readonly) BOOL hasContainerView;
 
-@property (nonatomic, copy, nullable) NSString *placement;
-@property (nonatomic, copy, nullable) NSString *customData;
-@property (nonatomic, copy, nullable) NSDictionary<NSString *, id> *extraParameters;
-@property (nonatomic, copy, nullable) NSDictionary<NSString *, id> *localExtraParameters;
-@property (nonatomic, assign, getter=isAutoRefreshEnabled) BOOL autoRefreshEnabled;
+- (void)setPlacement:(NSString *)placement;
+- (void)setCustomData:(NSString *)customData;
+- (void)setExtraParameters:(NSDictionary<NSString *, id> *)parameterDict;
+- (void)setLocalExtraParameters:(NSDictionary<NSString *, id> *)parameterDict;
+- (void)setAutoRefreshEnabled:(BOOL)autoRefresh;
 
 - (void)loadAd;
 - (void)attachAdView:(AppLovinMAXAdView *)view;

--- a/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.h
+++ b/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.h
@@ -8,11 +8,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy,   readonly) NSString *adUnitIdentifier;
 @property (nonatomic, assign, readonly) BOOL hasContainerView;
 
-- (void)setPlacement:(NSString *)placement;
-- (void)setCustomData:(NSString *)customData;
-- (void)setExtraParameters:(NSDictionary<NSString *, id> *)parameterDict;
-- (void)setLocalExtraParameters:(NSDictionary<NSString *, id> *)parameterDict;
-- (void)setAutoRefreshEnabled:(BOOL)autoRefresh;
+- (void)setPlacement:(nullable NSString *)placement;
+- (void)setCustomData:(nullable NSString *)customData;
+- (void)setExtraParameters:(nullable NSDictionary<NSString *, id> *)extraParameters;
+- (void)setLocalExtraParameters:(nullable NSDictionary<NSString *, id> *)localExtraParameters;
+- (void)setAutoRefreshEnabled:(BOOL)autoRefreshEnabled;
 
 - (void)loadAd;
 - (void)attachAdView:(AppLovinMAXAdView *)view;

--- a/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
+++ b/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
@@ -12,7 +12,6 @@
 @end
 
 @implementation AppLovinMAXAdViewWidget
-@dynamic placement, customData, extraParameters, localExtraParameters, autoRefreshEnabled;
 
 - (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat
 {
@@ -83,11 +82,6 @@
     {
         [self.adView stopAutoRefresh];
     }
-}
-
--(BOOL)isAutoRefreshEnabled
-{
-    return self.autoRefreshEnabled;
 }
 
 - (BOOL)hasContainerView

--- a/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
+++ b/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
@@ -12,6 +12,7 @@
 @end
 
 @implementation AppLovinMAXAdViewWidget
+@dynamic placement, customData, extraParameters, localExtraParameters, autoRefreshEnabled;
 
 - (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat
 {
@@ -55,18 +56,6 @@
     self.adView.customData = customData;
 }
 
-- (void)setAutoRefreshEnabled:(BOOL)autoRefresh
-{
-    if ( autoRefresh )
-    {
-        [self.adView startAutoRefresh];
-    }
-    else
-    {
-        [self.adView stopAutoRefresh];
-    }
-}
-
 - (void)setExtraParameters:(NSDictionary<NSString *, id> *)parameterDict
 {
     for ( NSString *key in parameterDict )
@@ -82,6 +71,23 @@
         id value = parameterDict[key];
         [self.adView setLocalExtraParameterForKey: key value: (value != [NSNull null] ? value : nil)];
     }
+}
+
+- (void)setAutoRefreshEnabled:(BOOL)autoRefresh
+{
+    if ( autoRefresh )
+    {
+        [self.adView startAutoRefresh];
+    }
+    else
+    {
+        [self.adView stopAutoRefresh];
+    }
+}
+
+-(BOOL)isAutoRefreshEnabled
+{
+    return self.autoRefreshEnabled;
 }
 
 - (BOOL)hasContainerView

--- a/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
+++ b/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
@@ -45,36 +45,36 @@
     return self.adView.adUnitIdentifier;
 }
 
-- (void)setPlacement:(NSString *)placement
+- (void)setPlacement:(nullable NSString *)placement
 {
     self.adView.placement = placement;
 }
 
-- (void)setCustomData:(NSString *)customData
+- (void)setCustomData:(nullable NSString *)customData
 {
     self.adView.customData = customData;
 }
 
-- (void)setExtraParameters:(NSDictionary<NSString *, id> *)parameterDict
+- (void)setExtraParameters:(nullable NSDictionary<NSString *, id> *)extraParameters
 {
-    for ( NSString *key in parameterDict )
+    for ( NSString *key in extraParameters )
     {
-        [self.adView setExtraParameterForKey: key value: [parameterDict al_stringForKey: key]];
+        [self.adView setExtraParameterForKey: key value: [extraParameters al_stringForKey: key]];
     }
 }
 
-- (void)setLocalExtraParameters:(NSDictionary<NSString *, id> *)parameterDict
+- (void)setLocalExtraParameters:(nullable NSDictionary<NSString *, id> *)localExtraParameters
 {
-    for ( NSString *key in parameterDict )
+    for ( NSString *key in localExtraParameters )
     {
-        id value = parameterDict[key];
+        id value = localExtraParameters[key];
         [self.adView setLocalExtraParameterForKey: key value: (value != [NSNull null] ? value : nil)];
     }
 }
 
-- (void)setAutoRefreshEnabled:(BOOL)autoRefresh
+- (void)setAutoRefreshEnabled:(BOOL)autoRefreshEnabled
 {
-    if ( autoRefresh )
+    if ( autoRefreshEnabled )
     {
         [self.adView startAutoRefresh];
     }

--- a/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
+++ b/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
@@ -55,7 +55,7 @@
     self.adView.customData = customData;
 }
 
-- (void)setAutoRefresh:(BOOL)autoRefresh
+- (void)setAutoRefreshEnabled:(BOOL)autoRefresh
 {
     if ( autoRefresh )
     {


### PR DESCRIPTION
Fix preloaded AdView not resuming auto-refresh on iOS.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the issue where preloaded AdView components in iOS do not resume auto-refresh by renaming the method to `setAutoRefreshEnabled`.

### Why are these changes being made?

The existing implementation had a bug that prevented auto-refresh functionality from resuming on preloaded AdView components specifically for iOS devices. Renaming the method to `setAutoRefreshEnabled` correctly reflects its functionality, ensuring that auto-refresh is managed appropriately when preloaded AdView components are used.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->