### PR TITLE
4.1.2

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Versions
 
-## x.x.x
+## 4.1.2
 * Fix preloaded banners and MRECs not resuming auto-refresh on iOS.
 ## 4.1.1
 * Remove the mistakenly enabled adaptive banner from Android to prevent app-side errors.

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
@@ -63,7 +63,7 @@ public class AppLovinMAX
 {
     private static final String SDK_TAG        = "AppLovinSdk";
     public static final  String TAG            = "AppLovinMAX";
-    private static final String PLUGIN_VERSION = "4.1.1";
+    private static final String PLUGIN_VERSION = "4.1.2";
 
     private static final String USER_GEOGRAPHY_GDPR    = "G";
     private static final String USER_GEOGRAPHY_OTHER   = "O";
@@ -73,6 +73,7 @@ public class AppLovinMAX
 
     static
     {
+        ALCompatibleNativeSdkVersions.put( "4.1.2", "13.0.1" );
         ALCompatibleNativeSdkVersions.put( "4.1.1", "13.0.1" );
         ALCompatibleNativeSdkVersions.put( "4.1.0", "13.0.1" );
         ALCompatibleNativeSdkVersions.put( "4.0.2", "13.0.0" );

--- a/applovin_max/example/ios/Podfile.lock
+++ b/applovin_max/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - applovin_max (4.1.1):
+  - applovin_max (4.1.2):
     - AppLovinSDK (= 13.0.1)
     - Flutter
   - AppLovinSDK (13.0.1)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  applovin_max: 2d4559f5cae0870d8903866411d98f7f1b5384b0
+  applovin_max: f85eaf826af6801fdfccd9cf5100bfade96b4040
   AppLovinSDK: fdae6a4361c9c9b09f8d7d18ede792368221d987
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
 

--- a/applovin_max/ios/Classes/AppLovinMAX.m
+++ b/applovin_max/ios/Classes/AppLovinMAX.m
@@ -53,7 +53,7 @@
 @implementation AppLovinMAX
 static NSString *const SDK_TAG = @"AppLovinSdk";
 static NSString *const TAG = @"AppLovinMAX";
-static NSString *const PLUGIN_VERSION = @"4.1.1";
+static NSString *const PLUGIN_VERSION = @"4.1.2";
 
 static NSString *const USER_GEOGRAPHY_GDPR = @"G";
 static NSString *const USER_GEOGRAPHY_OTHER = @"O";
@@ -74,6 +74,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar
 {
     ALCompatibleNativeSDKVersions = @{
+        @"4.1.2" : @"13.0.1",
         @"4.1.1" : @"13.0.1",
         @"4.1.0" : @"13.0.1",
         @"4.0.2" : @"13.0.0",

--- a/applovin_max/ios/applovin_max.podspec
+++ b/applovin_max/ios/applovin_max.podspec
@@ -5,7 +5,7 @@
 Pod::Spec.new do |s|
   s.authors          = 'AppLovin Corporation'
   s.name             = 'applovin_max'
-  s.version          = '4.1.1'
+  s.version          = '4.1.2'
   s.summary          = 'AppLovin MAX Flutter Plugin'
   s.description      = <<-DESC
 AppLovin MAX Flutter Plugin

--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -13,7 +13,7 @@ export 'package:applovin_max/src/max_ad_view.dart';
 export 'package:applovin_max/src/max_native_ad_view.dart';
 
 /// The current version of the SDK.
-const String _version = "4.1.1";
+const String _version = "4.1.2";
 
 /// Represents the AppLovin SDK.
 class AppLovinMAX {

--- a/applovin_max/pubspec.yaml
+++ b/applovin_max/pubspec.yaml
@@ -1,6 +1,6 @@
 name: applovin_max
 description: AppLovin MAX Flutter Plugin for Android and iOS - with support for interstitial ads, rewarded ads, banners, and MRECs.
-version: 4.1.1
+version: 4.1.2
 homepage: https://github.com/AppLovin/AppLovin-MAX-Flutter
 
 environment:


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the AppLovin MAX Flutter Plugin version to 4.1.2 and fix an issue with preloaded banners and MRECs not resuming auto-refresh on iOS.

### Why are these changes being made?

The version update to 4.1.2 ensures consistency across all project files, while the issue fix addresses a crucial bug that affected the auto-refresh functionality on iOS, which is necessary for proper ad display and performance.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->