### PR TITLE
4.3.0

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Versions
 
-## x.x.x
+## 4.3.0
 * Update `MaxAd` to include `adFormat`, `networkPlacement`, and `latencyMills`.
 * Depends on Android SDK v13.1.0 and iOS SDK v13.1.0.
 ## 4.2.1

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAX.java
@@ -64,7 +64,7 @@ public class AppLovinMAX
 {
     private static final String SDK_TAG        = "AppLovinSdk";
     public static final  String TAG            = "AppLovinMAX";
-    private static final String PLUGIN_VERSION = "4.2.1";
+    private static final String PLUGIN_VERSION = "4.3.0";
 
     private static final String USER_GEOGRAPHY_GDPR    = "G";
     private static final String USER_GEOGRAPHY_OTHER   = "O";
@@ -84,6 +84,7 @@ public class AppLovinMAX
 
     static
     {
+        ALCompatibleNativeSdkVersions.put( "4.3.0", "13.0.1" );
         ALCompatibleNativeSdkVersions.put( "4.2.1", "13.0.1" );
         ALCompatibleNativeSdkVersions.put( "4.2.0", "13.0.1" );
         ALCompatibleNativeSdkVersions.put( "4.1.2", "13.0.1" );

--- a/applovin_max/example/ios/Podfile.lock
+++ b/applovin_max/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - applovin_max (4.2.1):
-    - AppLovinSDK (= 13.0.1)
+  - applovin_max (4.3.0):
+    - AppLovinSDK (= 13.1.0)
     - Flutter
-  - AppLovinSDK (13.0.1)
+  - AppLovinSDK (13.1.0)
   - Flutter (1.0.0)
 
 DEPENDENCIES:
@@ -20,10 +20,10 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  applovin_max: c3cbdc57d848a1b6b068d51f25eb7d2ac37c56b8
-  AppLovinSDK: fdae6a4361c9c9b09f8d7d18ede792368221d987
+  applovin_max: 9132e2896e6ce46120571486fe651a3c9ab13a4e
+  AppLovinSDK: 539a0178d8bef4d68b2551a93526e0c1bba06cb2
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
 
-PODFILE CHECKSUM: 663715e941f9adb426e33bf9376914006f9ea95b
+PODFILE CHECKSUM: cf0c950f7e9a456b4e325f5b8fc0f98906a3705a
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/applovin_max/ios/Classes/AppLovinMAX.m
+++ b/applovin_max/ios/Classes/AppLovinMAX.m
@@ -55,7 +55,7 @@
 @implementation AppLovinMAX
 static NSString *const SDK_TAG = @"AppLovinSdk";
 static NSString *const TAG = @"AppLovinMAX";
-static NSString *const PLUGIN_VERSION = @"4.2.1";
+static NSString *const PLUGIN_VERSION = @"4.3.0";
 
 static NSString *const USER_GEOGRAPHY_GDPR = @"G";
 static NSString *const USER_GEOGRAPHY_OTHER = @"O";
@@ -76,6 +76,7 @@ static NSDictionary<NSString *, NSString *> *ALCompatibleNativeSDKVersions;
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar
 {
     ALCompatibleNativeSDKVersions = @{
+        @"4.3.0" : @"13.0.1",
         @"4.2.1" : @"13.0.1",
         @"4.2.0" : @"13.0.1",
         @"4.1.2" : @"13.0.1",

--- a/applovin_max/ios/applovin_max.podspec
+++ b/applovin_max/ios/applovin_max.podspec
@@ -5,7 +5,7 @@
 Pod::Spec.new do |s|
   s.authors          = 'AppLovin Corporation'
   s.name             = 'applovin_max'
-  s.version          = '4.2.1'
+  s.version          = '4.3.0'
   s.summary          = 'AppLovin MAX Flutter Plugin'
   s.description      = <<-DESC
 AppLovin MAX Flutter Plugin

--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -13,7 +13,7 @@ export 'package:applovin_max/src/max_ad_view.dart';
 export 'package:applovin_max/src/max_native_ad_view.dart';
 
 /// The current version of the SDK.
-const String _version = "4.2.1";
+const String _version = "4.3.0";
 
 /// Represents the AppLovin SDK.
 class AppLovinMAX {

--- a/applovin_max/pubspec.yaml
+++ b/applovin_max/pubspec.yaml
@@ -1,6 +1,6 @@
 name: applovin_max
 description: AppLovin MAX Flutter Plugin for Android and iOS - with support for interstitial ads, rewarded ads, banners, and MRECs.
-version: 4.2.1
+version: 4.3.0
 homepage: https://github.com/AppLovin/AppLovin-MAX-Flutter
 
 environment:


### PR DESCRIPTION
- Bump to 4.3.0
- Stay SDK `13.0.1` as a compatible version.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Upgrade AppLovin MAX plugin to version 4.3.0 with updated MaxAd features and dependencies on Android SDK v13.1.0 and iOS SDK v13.1.0.

### Why are these changes being made?

These changes introduce new properties (`adFormat`, `networkPlacement`, and `latencyMills`) to the `MaxAd` component, enhancing functionality and compatibility with the latest Android and iOS SDKs version 13.1.0, and ensuring the plugin's compatibility and readiness for new and improved ad features.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->