### PR TITLE
ref/remove_setlocationcollectionenabled

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Deprecate `AppLovinMAX.setLocationCollectionEnabled()` for removal.
 ## 4.3.0
 * Update `MaxAd` to include `adFormat`, `networkPlacement`, and `latencyMills`.
 * Depends on Android SDK v13.1.0 and iOS SDK v13.1.0.

--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Deprecate `AppLovinMAX.setLocationCollectionEnabled()` for removal.
+* Remove deprecated `AppLovinMAX.setLocationCollectionEnabled()` API.
 ## 4.3.0
 * Update `MaxAd` to include `adFormat`, `networkPlacement`, and `latencyMills`.
 * Depends on Android SDK v13.1.0 and iOS SDK v13.1.0.

--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -275,15 +275,6 @@ class AppLovinMAX {
     });
   }
 
-  /// Whether or not the AppLovin SDK will collect the device location. Defaults to true.
-  ///
-  /// [Location Passing](https://developers.applovin.com/en/flutter/overview/data-and-keyword-passing#location-passing)
-  static void setLocationCollectionEnabled(bool enabled) {
-    _methodChannel.invokeMethod('setLocationCollectionEnabled', {
-      'value': enabled,
-    });
-  }
-
   /// Sets an extra parameter to pass to the AppLovin server.
   static void setExtraParameter(String key, String? value) {
     _methodChannel.invokeMethod('setExtraParameter', {


### PR DESCRIPTION
Deprecate AppLovinMAX.setLocationCollectionEnabled() for removal (#303).

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Deprecate and remove the `AppLovinMAX.setLocationCollectionEnabled()` method from the codebase.

### Why are these changes being made?

The method is being deprecated because it is likely no longer needed or its functionality has been replaced or deprecated within the AppLovin SDK. This change simplifies the API and reduces maintenance overhead by aligning with the current SDK requirements. 

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->