### PR TITLE
fix/native_ad_cta_not_clickable

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Fix CTA not clickable.
 * Remove deprecated `AppLovinMAX.setLocationCollectionEnabled()` API.
 ## 4.3.0
 * Update `MaxAd` to include `adFormat`, `networkPlacement`, and `latencyMills`.

--- a/applovin_max/ios/Classes/AppLovinMAXNativeAdView.m
+++ b/applovin_max/ios/Classes/AppLovinMAXNativeAdView.m
@@ -281,6 +281,7 @@
     [self.clickableViews addObject: self.titleView];
     
     self.titleView.frame = [self frameForCall: call];
+    self.titleView.userInteractionEnabled = YES;
 }
 
 - (void)addAdvertiserViewForCall:(FlutterMethodCall *)call
@@ -297,6 +298,7 @@
     [self.clickableViews addObject: self.advertiserView];
     
     self.advertiserView.frame = [self frameForCall: call];
+    self.advertiserView.userInteractionEnabled = YES;
 }
 
 - (void)addBodyViewForCall:(FlutterMethodCall *)call
@@ -313,6 +315,7 @@
     [self.clickableViews addObject: self.bodyView];
     
     self.bodyView.frame = [self frameForCall: call];
+    self.bodyView.userInteractionEnabled = YES;
 }
 
 - (void)addCallToActionViewForCall:(FlutterMethodCall *)call
@@ -329,6 +332,7 @@
     [self.clickableViews addObject: self.callToActionView];
     
     self.callToActionView.frame = [self frameForCall: call];
+    self.callToActionView.userInteractionEnabled = YES;
 }
 
 - (void)addIconViewForCall:(FlutterMethodCall *)call
@@ -352,6 +356,7 @@
     [self.clickableViews addObject: self.iconView];
     
     self.iconView.frame = [self frameForCall: call];
+    self.iconView.userInteractionEnabled = YES;
     
     if ( icon )
     {
@@ -416,19 +421,25 @@
 
 - (void)renderAd
 {
-    if ( self.adLoader )
+    if ( !self.adLoader )
     {
+        [self.isLoading set: NO];
+
+        [AppLovinMAX log: @"Attempting to render ad before ad has been loaded for Ad Unit ID %@", self.adUnitId];
+
+        return;
+    }
+    
+    // Flutter calls `renderAd()` multiple times whenever the asset views are updated
+    if ( [self.isLoading compareAndSet: YES update: NO] )
+    {
+        [AppLovinMAX log: @"Render ad for Ad Unit ID %@", self.adUnitId];
+        
         [self.adLoader registerClickableViews: self.clickableViews
                                 withContainer: self.nativeAdView
                                         forAd: self.nativeAd];
         [self.adLoader handleNativeAdViewRenderedForAd: self.nativeAd];
     }
-    else
-    {
-        [AppLovinMAX log: @"Attempting to render ad before ad has been loaded for Ad Unit ID %@", self.adUnitId];
-    }
-    
-    [self.isLoading set: NO];
 }
 
 - (CGRect)frameForCall:(FlutterMethodCall *)call

--- a/applovin_max/lib/src/max_native_ad_view.dart
+++ b/applovin_max/lib/src/max_native_ad_view.dart
@@ -185,10 +185,10 @@ class _MaxNativeAdViewState extends State<MaxNativeAdView> {
         widget.listener?.onAdLoadedCallback(maxAd);
 
         // Add or update all native ad asset views (e.g., title, body, icon) on the platform.
-        _updateAllAssetViews();
+        await _updateAllAssetViews();
 
         // Register clickable views and initiate the rendering of the native ad on the platform.
-        _renderAd();
+        await _renderAd();
 
         // Update the Flutter asset views with the native ad
         setState(() {
@@ -208,18 +208,20 @@ class _MaxNativeAdViewState extends State<MaxNativeAdView> {
     }
   }
 
-  void _updateAllAssetViews() {
-    _updateAssetView(_iconViewKey, "addIconView");
-    _updateAssetView(_optionsViewKey, "addOptionsView");
-    _updateAssetView(_mediaViewKey, "addMediaView");
-    _updateAssetView(_titleViewKey, "addTitleView");
-    _updateAssetView(_advertiserViewKey, "addAdvertiserView");
-    _updateAssetView(_bodyViewKey, "addBodyView");
-    _updateAssetView(_callToActionViewKey, "addCallToActionView");
+  Future _updateAllAssetViews() async {
+    return Future.wait([
+      _updateAssetView(_mediaViewKey, "addMediaView"),
+      _updateAssetView(_iconViewKey, "addIconView"),
+      _updateAssetView(_optionsViewKey, "addOptionsView"),
+      _updateAssetView(_titleViewKey, "addTitleView"),
+      _updateAssetView(_advertiserViewKey, "addAdvertiserView"),
+      _updateAssetView(_bodyViewKey, "addBodyView"),
+      _updateAssetView(_callToActionViewKey, "addCallToActionView")
+    ]);
   }
 
   // Updates the specified asset view's position and size on the platform using the provided method name.
-  void _updateAssetView(GlobalKey? key, String method) {
+  Future _updateAssetView(GlobalKey? key, String method) async {
     if (key == null) return;
 
     Rect rect = _getViewSize(key, _nativeAdViewKey);
@@ -246,11 +248,11 @@ class _MaxNativeAdViewState extends State<MaxNativeAdView> {
       return;
     }
 
-    _methodChannel?.invokeMethod(method, params);
+    return _methodChannel?.invokeMethod(method, params);
   }
 
-  void _renderAd() {
-    _methodChannel?.invokeMethod("renderAd");
+  Future _renderAd() async {
+    return _methodChannel?.invokeMethod("renderAd");
   }
 
   // Returns the frame (rect) size relative to the parent's position


### PR DESCRIPTION
Fix the following issues to ensure the CTA works correctly:

- Google ads reset the `userInteraction` state when they are removed.
- `renderAd()` is called multiple times whenever the asset views are updated.
- `renderAd()` may be called before all asset views have been applied.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enable user interaction on native ad components to fix the issue of unclickable CTA buttons and update the asset view handling to be asynchronous in the `applovin_max` plugin.

### Why are these changes being made?

These changes address an issue where Call-To-Action buttons in native ads were not clickable by ensuring `userInteractionEnabled` is set to `YES` for relevant views. Additionally, converting asset view updates and render calls to asynchronous operations improves the rendering sequence and performance when loading and displaying native ads.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->