### PR TITLE
ref/remove_deprecated_targeting_apis

### DIFF
--- a/applovin_max/lib/src/enums.dart
+++ b/applovin_max/lib/src/enums.dart
@@ -44,46 +44,6 @@ enum AdViewPosition {
   const AdViewPosition(this.value);
 }
 
-/// Represents content ratings for ads shown to users.
-///
-/// Corresponds to IQG media content ratings.
-enum AdContentRating {
-  /// No content rating.
-  none(0),
-
-  /// Suitable for all audiences.
-  allAudiences(1),
-
-  /// Suitable for users aged 12 and above.
-  everyoneOverTwelve(2),
-
-  /// Suitable for mature audiences only.
-  matureAudiences(3);
-
-  /// @nodoc
-  final int value;
-  const AdContentRating(this.value);
-}
-
-/// User's gender for ad targeting.
-enum UserGender {
-  /// Unknown gender.
-  unknown('U'),
-
-  /// Female.
-  female('F'),
-
-  /// Male.
-  male('M'),
-
-  /// Other or non-binary.
-  other('O');
-
-  /// @nodoc
-  final String value;
-  const UserGender(this.value);
-}
-
 /// User's geography for determining consent flow.
 enum ConsentFlowUserGeography {
   /// User's geography is unknown.


### PR DESCRIPTION
Remove deprecated targeting APIs.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Remove deprecated `AdContentRating` and `UserGender` enums from the codebase.

### Why are these changes being made?
These targeting APIs are being deprecated because they are no longer supported or necessary for ad content rating and user gender targeting, streamlining the code to align with updated practices and improving maintainability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->