### PR TITLE
feat/depend_on_Android_SDK_13.2.0_and_iOS_SDK_13.2.0

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Depends on Android SDK v13.2.0 and iOS SDK v13.2.0.
 ## 4.3.1
 * Fix CTA not clickable.
 * Remove deprecated `AppLovinMAX.setLocationCollectionEnabled()` API.

--- a/applovin_max/android/build.gradle
+++ b/applovin_max/android/build.gradle
@@ -38,6 +38,6 @@ android {
     }
 
     dependencies {
-        api 'com.applovin:applovin-sdk:13.1.0'
+        api 'com.applovin:applovin-sdk:13.2.0'
     }
 }

--- a/applovin_max/example/ios/Podfile.lock
+++ b/applovin_max/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - applovin_max (4.3.1):
-    - AppLovinSDK (= 13.1.0)
+    - AppLovinSDK (= 13.2.0)
     - Flutter
-  - AppLovinSDK (13.1.0)
+  - AppLovinSDK (13.2.0)
   - Flutter (1.0.0)
 
 DEPENDENCIES:
@@ -20,10 +20,10 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  applovin_max: 8564892edf7676734be8439afe6de16c6917c97a
-  AppLovinSDK: 539a0178d8bef4d68b2551a93526e0c1bba06cb2
+  applovin_max: 6fad152f8eae48801909e2b2a525c76f4656b54c
+  AppLovinSDK: 1eb88a82b4feea9f3696ce9cc1e3343c4997ee12
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
 
-PODFILE CHECKSUM: f6d4310a5f7d7eaefabe9a19f7ba5dcdcecc57fb
+PODFILE CHECKSUM: 663715e941f9adb426e33bf9376914006f9ea95b
 
 COCOAPODS: 1.16.2

--- a/applovin_max/ios/applovin_max.podspec
+++ b/applovin_max/ios/applovin_max.podspec
@@ -18,7 +18,7 @@ DESC
   s.platform = :ios, '12.0'
   s.static_framework = true
   s.dependency 'Flutter'
-  s.dependency 'AppLovinSDK', '13.1.0'
+  s.dependency 'AppLovinSDK', '13.2.0'
   
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
Depends on Android SDK v13.2.0 and iOS SDK v13.2.0.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Depend on Android SDK v13.2.0 and iOS SDK v13.2.0 by updating the `applovin-sdk` versions in build.gradle and podspec files, and reflect the changes in the changelog.

### Why are these changes being made?
The updates ensure compatibility with the latest features and fixes provided in Android SDK v13.2.0 and iOS SDK v13.2.0, which may improve the functionality and stability of the application. This approach allows the integration of the most recent enhancements and maintains up-to-date dependencies crucial for performance and security.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->