### PR TITLE
ref/update_adview_props

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Versions
 
+## x.x.x
+* Add `adaptiveBannerEnabled` prop to `MaxAdView`.
+* Rename `isAutoRefreshEnabled` to `autoRefreshEnabled` in `MaxAdView` for consistency.
 ## 4.4.0
 * Depends on Android SDK v13.2.0 and iOS SDK v13.2.0.
 ## 4.3.1

--- a/applovin_max/lib/src/max_ad_view.dart
+++ b/applovin_max/lib/src/max_ad_view.dart
@@ -73,7 +73,10 @@ class MaxAdView extends StatefulWidget {
   final AdViewAdListener? listener;
 
   /// Whether auto-refresh is enabled. Defaults to `true`.
-  final bool isAutoRefreshEnabled;
+  final bool autoRefreshEnabled;
+
+  /// Whether adaptive banner sizing is enabled. Defaults to `true`.
+  final bool adaptiveBannerEnabled;
 
   /// The ad width. If `null`, a default is computed based on [adFormat] and layout constraints.
   ///
@@ -103,7 +106,8 @@ class MaxAdView extends StatefulWidget {
     this.extraParameters,
     this.localExtraParameters,
     this.listener,
-    this.isAutoRefreshEnabled = true,
+    this.autoRefreshEnabled = true,
+    this.adaptiveBannerEnabled = true,
     this.width,
     this.height,
   }) : super(key: key);
@@ -119,29 +123,18 @@ class _MaxAdViewState extends State<MaxAdView> {
 
   late Size _screenSize;
   late bool _isTablet;
-  late bool _adaptiveBannerEnabled;
-  late Map<String, String?> extraParameters;
 
   @override
   void initState() {
     super.initState();
-
-    extraParameters = Map<String, String?>.from(widget.extraParameters ?? {});
-    if (extraParameters['adaptive_banner'] == null) {
-      // Set the default value for 'adaptive_banner'
-      extraParameters['adaptive_banner'] = 'true';
-      _adaptiveBannerEnabled = true;
-    } else {
-      _adaptiveBannerEnabled = extraParameters['adaptive_banner'] == 'true';
-    }
   }
 
   @override
   void didUpdateWidget(MaxAdView oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (oldWidget.isAutoRefreshEnabled != widget.isAutoRefreshEnabled) {
-      if (widget.isAutoRefreshEnabled) {
+    if (oldWidget.autoRefreshEnabled != widget.autoRefreshEnabled) {
+      if (widget.autoRefreshEnabled) {
         _methodChannel?.invokeMethod('startAutoRefresh');
       } else {
         _methodChannel?.invokeMethod('stopAutoRefresh');
@@ -203,10 +196,10 @@ class _MaxAdViewState extends State<MaxAdView> {
       "ad_unit_id": widget.adUnitId,
       "ad_format": widget.adFormat.value,
       "ad_view_id": widget.adViewId,
-      "is_auto_refresh_enabled": widget.isAutoRefreshEnabled,
+      "is_auto_refresh_enabled": widget.autoRefreshEnabled,
       "custom_data": widget.customData,
       "placement": widget.placement,
-      "extra_parameters": extraParameters,
+      "extra_parameters": widget.extraParameters,
       "local_extra_parameters": widget.localExtraParameters,
     };
   }
@@ -258,7 +251,7 @@ class _MaxAdViewState extends State<MaxAdView> {
       return _mrecWidth;
     } else if (widget.adFormat == AdFormat.banner) {
       // Return the screen size when adaptive banner is enabled.
-      if (_adaptiveBannerEnabled) {
+      if (widget.adaptiveBannerEnabled) {
         return _screenSize.width;
       }
       return _isTablet ? _leaderWidth : _bannerWidth;
@@ -271,7 +264,7 @@ class _MaxAdViewState extends State<MaxAdView> {
     if (widget.adFormat == AdFormat.mrec) {
       return _mrecHeight;
     } else if (widget.adFormat == AdFormat.banner) {
-      if (_adaptiveBannerEnabled) {
+      if (widget.adaptiveBannerEnabled) {
         return await AppLovinMAX.getAdaptiveBannerHeightForWidth(width) ?? (_isTablet ? _leaderHeight : _bannerHeight);
       }
       return _isTablet ? _leaderHeight : _bannerHeight;


### PR DESCRIPTION
There are discrepancies between the AdView props in React Native and Flutter:

React Native | Flutter|Suggested Common Prop
-- | --|--
autoRefresh | isAutoRefreshEnabled|autoRefreshEnabled
adaptiveBannerEnabled | (not available)|adaptiveBannerEnabled

This PR renamed `isAutoRefreshEnabled` to `autoRefreshEnabled` and added `adaptiveBannerEnabled`.   If this looks good, will update the React Native for consistency.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add an `adaptiveBannerEnabled` property to `MaxAdView` and rename the `isAutoRefreshEnabled` property to `autoRefreshEnabled` for consistency.

### Why are these changes being made?
The addition of the `adaptiveBannerEnabled` property allows for better handling of adaptive banner sizing, ensuring that it defaults to `true`. The renaming of the `isAutoRefreshEnabled` property to `autoRefreshEnabled` enhances consistency within the codebase, aligning with naming conventions used for other properties.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->