### PR TITLE
feat/use_max_ad_view_configuration_for_adaptive_banners

### DIFF
--- a/applovin_max/CHANGELOG.md
+++ b/applovin_max/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Add optional `isAdaptive` flag to `AppLovinMAX.createBanner()` and `AppLovinMAX.preloadWidgetAdView()` to enable adaptive banners (default: true).
 * Fix support for adaptive banners. For more info, check out our [docs](https://developers.applovin.com/en/max/flutter/ad-formats/banner-and-mrec-ads#adaptive-banners).
 ## 4.4.0
 * Depends on Android SDK v13.2.0 and iOS SDK v13.2.0.

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdView.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdView.java
@@ -58,7 +58,7 @@ public class AppLovinMAXAdView
 
     public static void preloadWidgetAdView(final String adUnitId,
                                            final MaxAdFormat adFormat,
-                                           final boolean isAdaptiveBannerEnabled,
+                                           final boolean isAdaptive,
                                            @Nullable final String placement,
                                            @Nullable final String customData,
                                            @Nullable final Map<String, Object> extraParameters,
@@ -66,7 +66,7 @@ public class AppLovinMAXAdView
                                            final Result result,
                                            final Context context)
     {
-        AppLovinMAXAdViewWidget preloadedWidget = new AppLovinMAXAdViewWidget( adUnitId, adFormat, isAdaptiveBannerEnabled, true, context );
+        AppLovinMAXAdViewWidget preloadedWidget = new AppLovinMAXAdViewWidget( adUnitId, adFormat, isAdaptive, true, context );
         preloadedWidgetInstances.put( preloadedWidget.hashCode(), preloadedWidget );
 
         preloadedWidget.setPlacement( placement );

--- a/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdViewWidget.java
+++ b/applovin_max/android/src/main/java/com/applovin/applovin_max/AppLovinMAXAdViewWidget.java
@@ -27,22 +27,32 @@ class AppLovinMAXAdViewWidget
     @Nullable
     private AppLovinMAXAdView containerView;
 
-    public AppLovinMAXAdViewWidget(final String adUnitId, final MaxAdFormat adFormat, final boolean isAdaptiveBannerEnabled, final Context context)
+    public AppLovinMAXAdViewWidget(final String adUnitId, final MaxAdFormat adFormat, final boolean isAdaptive, final Context context)
     {
-        this( adUnitId, adFormat, isAdaptiveBannerEnabled, false, context );
+        this( adUnitId, adFormat, isAdaptive, false, context );
     }
 
-    public AppLovinMAXAdViewWidget(final String adUnitId, final MaxAdFormat adFormat, final boolean isAdaptiveBannerEnabled, final boolean shouldPreloadWidget, final Context context)
+    public AppLovinMAXAdViewWidget(final String adUnitId, final MaxAdFormat adFormat, final boolean isAdaptive, final boolean shouldPreloadWidget, final Context context)
     {
         super( context );
 
         this.shouldPreloadWidget = shouldPreloadWidget;
 
-        MaxAdViewConfiguration config = MaxAdViewConfiguration.builder()
-                .setAdaptiveType( isAdaptiveBannerEnabled ? MaxAdViewConfiguration.AdaptiveType.ANCHORED : MaxAdViewConfiguration.AdaptiveType.NONE )
-                .build();
+        MaxAdViewConfiguration.Builder builder = MaxAdViewConfiguration.builder();
 
-        adView = new MaxAdView( adUnitId, adFormat, config );
+        if ( adFormat.isBannerOrLeaderAd() )
+        {
+            if ( isAdaptive )
+            {
+                builder.setAdaptiveType( MaxAdViewConfiguration.AdaptiveType.ANCHORED );
+            }
+            else
+            {
+                builder.setAdaptiveType( MaxAdViewConfiguration.AdaptiveType.NONE );
+            }
+        }
+
+        adView = new MaxAdView( adUnitId, adFormat, builder.build() );
         adView.setListener( this );
         adView.setRevenueListener( this );
 

--- a/applovin_max/ios/Classes/AppLovinMAXAdView.h
+++ b/applovin_max/ios/Classes/AppLovinMAXAdView.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)preloadWidgetAdView:(NSString *)adUnitIdentifier 
                    adFormat:(MAAdFormat *)adFormat
-    isAdaptiveBannerEnabled:(BOOL)isAdaptiveBannerEnabled
+                 isAdaptive:(BOOL)isAdaptive
                   placement:(nullable NSString *)placement
                  customData:(nullable NSString *)customData
             extraParameters:(nullable NSDictionary<NSString *, id> *)extraParameters

--- a/applovin_max/ios/Classes/AppLovinMAXAdView.m
+++ b/applovin_max/ios/Classes/AppLovinMAXAdView.m
@@ -58,14 +58,14 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewWidget *> *preloadedWidg
 
 + (void)preloadWidgetAdView:(NSString *)adUnitIdentifier
                    adFormat:(MAAdFormat *)adFormat
-    isAdaptiveBannerEnabled:(BOOL)isAdaptiveBannerEnabled
+                 isAdaptive:(BOOL)isAdaptive
                   placement:(nullable NSString *)placement
                  customData:(nullable NSString *)customData
             extraParameters:(nullable NSDictionary<NSString *, id> *)extraParameters
        localExtraParameters:(nullable NSDictionary<NSString *, id> *)localExtraParameters
                  withResult:(FlutterResult)result
 {
-    AppLovinMAXAdViewWidget *preloadedWidget = [[AppLovinMAXAdViewWidget alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat isAdaptiveBannerEnabled: isAdaptiveBannerEnabled shouldPreload: YES];
+    AppLovinMAXAdViewWidget *preloadedWidget = [[AppLovinMAXAdViewWidget alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat isAdaptive: isAdaptive shouldPreload: YES];
     preloadedWidgetInstances[@(preloadedWidget.hash)] = preloadedWidget;
     
     [preloadedWidget setPlacement: placement];
@@ -158,7 +158,7 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewWidget *> *preloadedWidg
             }
         }
         
-        self.widget = [[AppLovinMAXAdViewWidget alloc] initWithAdUnitIdentifier: adUnitId adFormat: adFormat isAdaptiveBannerEnabled: isAdaptiveBannerEnabled];
+        self.widget = [[AppLovinMAXAdViewWidget alloc] initWithAdUnitIdentifier: adUnitId adFormat: adFormat isAdaptive: isAdaptiveBannerEnabled];
         self.widget.adView.frame = frame;
         self.adViewId = @(self.widget.hash);
         widgetInstances[self.adViewId] = self.widget;

--- a/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.h
+++ b/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.h
@@ -19,8 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)detachAdView;
 - (void)destroy;
 
-- (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat isAdaptiveBannerEnabled:(BOOL)isAdaptiveBannerEnabled;
-- (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat isAdaptiveBannerEnabled:(BOOL)isAdaptiveBannerEnabled shouldPreload:(BOOL)shouldPreload;
+- (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat isAdaptive:(BOOL)isAdaptive;
+- (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat isAdaptive:(BOOL)isAdaptive shouldPreload:(BOOL)shouldPreload;
 
 @end
 

--- a/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
+++ b/applovin_max/ios/Classes/AppLovinMAXAdViewWidget.m
@@ -13,12 +13,12 @@
 
 @implementation AppLovinMAXAdViewWidget
 
-- (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat isAdaptiveBannerEnabled:(BOOL)isAdaptiveBannerEnabled
+- (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat isAdaptive:(BOOL)isAdaptive
 {
-    return [self initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat isAdaptiveBannerEnabled: isAdaptiveBannerEnabled shouldPreload: NO];
+    return [self initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat isAdaptive: isAdaptive shouldPreload: NO];
 }
 
-- (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat isAdaptiveBannerEnabled:(BOOL)isAdaptiveBannerEnabled shouldPreload:(BOOL)shouldPreload
+- (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat isAdaptive:(BOOL)isAdaptive shouldPreload:(BOOL)shouldPreload
 {
     self = [super init];
     if ( self )
@@ -26,9 +26,20 @@
         self.shouldPreload = shouldPreload;
         
         MAAdViewConfiguration *config = [MAAdViewConfiguration configurationWithBuilderBlock:^(MAAdViewConfigurationBuilder *builder) {
-            builder.adaptiveType = isAdaptiveBannerEnabled ? MAAdViewAdaptiveTypeAnchored : MAAdViewAdaptiveTypeNone;
+
+            if ( [adFormat isBannerOrLeaderAd] )
+            {
+                if ( isAdaptive )
+                {
+                    builder.adaptiveType = MAAdViewAdaptiveTypeAnchored;
+                }
+                else
+                {
+                    builder.adaptiveType = MAAdViewAdaptiveTypeNone;
+                }
+            }
         }];
-        
+
         self.adView = [[MAAdView alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat configuration: config];
         self.adView.delegate = self;
         self.adView.revenueDelegate = self;

--- a/applovin_max/lib/applovin_max.dart
+++ b/applovin_max/lib/applovin_max.dart
@@ -346,12 +346,12 @@ class AppLovinMAX {
   /// Creates a banner using your [adUnitId] at the specified [AdViewPosition] position.
   ///
   /// [Creating a Banner](https://developers.applovin.com/en/flutter/ad-formats/banner-mrec-ads)
-  static void createBanner(String adUnitId, AdViewPosition position) {
+  static void createBanner(String adUnitId, AdViewPosition position, [bool isAdaptive = true]) {
     _methodChannel.invokeMethod('createBanner', {
       'ad_unit_id': adUnitId,
       'position': position.value,
+      'is_adaptive': isAdaptive,
     });
-    setBannerExtraParameter(adUnitId, "adaptive_banner", "true");
   }
 
   /// Sets a background color for the banner with the specified [adUnitId].
@@ -710,7 +710,7 @@ class AppLovinMAX {
   static Future<AdViewId?> preloadWidgetAdView(
     String adUnitId,
     AdFormat adFormat, {
-    bool? isAdaptiveBannerEnabled,
+    bool? isAdaptive,
     String? placement,
     String? customData,
     Map<String, String?>? extraParameters,
@@ -719,7 +719,7 @@ class AppLovinMAX {
     return _methodChannel.invokeMethod('preloadWidgetAdView', {
       'ad_unit_id': adUnitId,
       'ad_format': adFormat.value,
-      'is_adaptive_banner_enabled': isAdaptiveBannerEnabled ?? true,
+      'is_adaptive': isAdaptive ?? true,
       'placement': placement,
       'custom_data': customData,
       'extra_parameters': extraParameters,


### PR DESCRIPTION
Use MAX AdView configuration for adaptive banners.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add an optional `isAdaptive` flag to the `AppLovinMAX.createBanner()` and `AppLovinMAX.preloadWidgetAdView()` methods to enable adaptive banners, defaulting to true, and update the internal methods to utilize this option correctly.

### Why are these changes being made?
The changes address the need for better control over banner adaptiveness, improving flexibility for developers using the AppLovin MAX SDK. This modernizes the approach by deprecating older methods of setting adaptive banners, enhancing configuration through a direct API mechanism, which aligns better with future plugin updates.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->