### PR TITLE
Bump Android compileSdkVersion from 31 to 36

### DIFF
--- a/applovin_max/android/build.gradle
+++ b/applovin_max/android/build.gradle
@@ -26,7 +26,7 @@ android {
         namespace 'com.applovin.applovin_max'
     }
 
-    compileSdkVersion 31
+    compileSdkVersion 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
## Summary

Fixes #344

Android Gradle Plugin 8.13.0+ enforces that all library dependencies satisfy their AAR metadata constraints. With `compileSdkVersion 31`, the build fails at `:applovin_max:checkReleaseAarMetadata` with up to 19 violations from AndroidX libraries that require compileSdk ≥ 33–34.

Bumping to **36 (Android 16)** resolves all constraint failures and keeps the plugin aligned with current platform requirements. `minSdkVersion 16` is unchanged.

## Test plan

- [ ] Run `flutter build apk` with Android Gradle Plugin 8.13.0+
- [ ] Confirm `:applovin_max:checkReleaseAarMetadata` passes without violations
- [ ] Confirm banner/interstitial/rewarded ads still load normally on a physical device